### PR TITLE
fixed issue #34

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -21,7 +21,7 @@ $(function () {
     var scrollbarLocation = $(this).scrollTop();
 
     scrollLink.each(function () {
-      var sectionOffset = $(this.hash).offset().top - 73;
+      var sectionOffset = Math.floor($(this).offset().top - 73);
 
       if (sectionOffset <= scrollbarLocation) {
         $(this).parent().addClass("active");


### PR DESCRIPTION
fixed #34 
There was some issue with `$(this.hash)` which is fixed by `$(this)` ( hash removed )

`var sectionOffset = $(this).offset().top - 73;`
This was returning float values due to which no operation can be performed thats y i use `var sectionOffset = Math.floor($(this).offset().top - 73);` which gives floor values 

and there is not conflict in file

**no error is showing while scrolling the window**

[Screencast from 11-05-24 06:32:56 PM IST.webm](https://github.com/ayush-that/FinVeda/assets/112775332/2bb20db0-9755-4f6a-aecc-477f9bf2f333)
