### PR TITLE
Added email Validation to accept approved domains

### DIFF
--- a/tools/emailValidation.js
+++ b/tools/emailValidation.js
@@ -1,0 +1,29 @@
+function validate() {
+    var mail = document.getElementById("text").value;
+  
+    const approvedDomains = [".com", ".in", ".org", ".net", ".edu"];
+  
+    
+    var regex = /^([a-zA-Z0-9\._]+)@([a-zA-Z0-9\-]+\.[a-zA-Z]{2,})$/;
+  
+    if (regex.test(mail)) {
+      const domain = mail.split('@')[1];
+  
+      const isValidDomain = approvedDomains.some((approvedDomain) => domain.endsWith(approvedDomain));
+  
+      if (isValidDomain) {
+        message.style.color = "green";
+        message.textContent = "Subscribed to the Newsletter!";
+        return true;
+      } else {
+        message.style.color = "red";
+        message.textContent = "Please enter a valid email with an approved domain (e.g., .com, .in)";
+        return false;
+      }
+    } else {
+        message.style.color = "red";
+        message.textContent = "Please enter a valid email ID";
+      return false;
+    }
+  }
+  

--- a/tools/sip.html
+++ b/tools/sip.html
@@ -278,8 +278,9 @@
           <div class="col-lg-6">
             <div class="subscribe-form mt-50">
               <form action="#">
-                <input type="text" placeholder="Enter Email" />
-                <button class="main-btn" onclick="event.preventDefault(); openModal();">Subscribe</button>
+                <input type="text" id="text" placeholder="Enter Email" />
+                <button type="button" onclick="validate()" class="main-btn">Subscribe</button>
+                <p id="message"></p>
               </form>
             </div>
           </div>
@@ -367,6 +368,7 @@
     <div id="particles-2"></div>
   </footer>
   <a href="#" class="back-to-top"><i class="lni-chevron-up"></i></a>
+  <script src="../tools/emailValidation.js"></script>
   <script src="../assets/js/vendor/jquery-1.12.4.min.js"></script>
   <script src="../assets/js/vendor/modernizr-3.7.1.min.js"></script>
   <script src="../assets/js/popper.min.js"></script>


### PR DESCRIPTION
This improvement ensures that only email addresses with specific domain extensions (e.g., ".com", ".in") are considered valid. It adds an additional layer of validation by checking if the domain part of the email address belongs to a pre-defined list of approved domains.
![image](https://github.com/ayush-that/FinVeda/assets/116087736/fc6a0d43-58b3-4e39-9049-89e764b91bd9)
![image](https://github.com/ayush-that/FinVeda/assets/116087736/b39a7f00-8d3f-49bc-b193-b6362f3d9129)
![image](https://github.com/ayush-that/FinVeda/assets/116087736/b45453cf-9815-4506-a3ee-80507fda97d2)
