### PR TITLE
Fixed issue of multiple reviews being highlighted simultaneously

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1666,14 +1666,6 @@ p {
   color: #fe7a7b;
 }
 
-.slick-center .single-testimonial {
-  border-color: #fe7a7b;
-}
-
-.slick-center .single-testimonial .testimonial-review .quota i {
-  color: #fe7a7b;
-}
-
 .testimonial-active .slick-dots {
   margin: 0 auto;
 }


### PR DESCRIPTION
### Overview
This pull request addresses a bug where multiple review cards were being highlighted at the same time. This fix ensures that only one review card can be highlighted at a time.

### Changes
- Modified the highlight logic to ensure only one card is highlighted at a time.

### Testing
- Verified that only one review card is highlighted when it is hovered over.
- Ensured that other cards are not affected by the highlight state.

### Additional Notes
Please review the changes and let me know if there are any further adjustments needed.