### PR TITLE
Added smooth transition back to top button

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -2022,34 +2022,43 @@ cursor: pointer;
 .copyright-content a:hover {
   color: #fe8464;
 }
+footer {
+  position: relative;
+  padding: 50px 0;
+}
 
-.back-to-top {
-  font-size: 20px;
-  color: #fff;
+#back-to-top-container {
   position: fixed;
-  right: 44px;
-  bottom: 5px;
-  width: 45px;
-  height: 40px;
-  line-height: 45px;
-  border-radius: 10px;
-  /* background: -webkit-linear-gradient(left, #361cc1 0%, #2e82ef 100%); */
-  /* background: -o-linear-gradient(left, #361cc1 0%, #2e82ef 100%); */
-  background: linear-gradient(to right, #7d91e9 0%, #6791db 100%);
-  text-align: center;
-  z-index: 99;
-  -webkit-transition: all 0.3s ease-out 0s;
-  -moz-transition: all 0.3s ease-out 0s;
-  -ms-transition: all 0.3s ease-out 0s;
-  -o-transition: all 0.3s ease-out 0s;
-  transition: all 0.3s ease-out ;
-  
+  bottom: 8px;
+  right: 44px; 
+  cursor: pointer;
+  z-index: 1000;
 }
 
-.back-to-top:hover {
-  color: #fff;
+.circle {
+  background-color: white; 
+  border-radius: 50%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  cursor: pointer;
+  transition: background-color 0.3s;
 }
 
+#back-to-top {
+  width: 35px; 
+  height: 35px; 
+  fill:  #505fde;
+  transition: fill 0.3s;
+}
+
+.circle:hover {
+  background-color: #fff;
+}
+
+#back-to-top:hover {
+  fill: hsl(234, 58%, 62%); 
+}
 ::-webkit-scrollbar {
   width: 15px;
 }

--- a/blog.html
+++ b/blog.html
@@ -361,9 +361,40 @@
         </div>
       </div>
       <div id="particles-2"></div>
+      <div id="back-to-top-container">
+        <div class="circle">
+      <svg id="back-to-top" xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-arrow-up-circle-fill" viewBox="0 0 16 16">
+        <path d="M16 8A8 8 0 1 0 0 8a8 8 0 0 0 16 0m-7.5 3.5a.5.5 0 0 1-1 0V5.707L5.354 7.854a.5.5 0 1 1-.708-.708l3-3a.5.5 0 0 1 .708 0l3 3a.5.5 0 0 1-.708.708L8.5 5.707z"/>
+      </svg>
+      </div>
+      </div>
     </footer>
     <script>document.getElementById("copyright-year").textContent = new Date().getFullYear();</script>
-    <a href="#" class="back-to-top"><i class="lni-chevron-up"></i></a>
+    <script>
+      document.addEventListener("DOMContentLoaded", function () {
+          const backToTopButton = document.getElementById('back-to-top-container');
+      
+          function checkButtonVisibility() {
+              if (window.innerWidth > 100 && window.scrollY > 100) {
+                  backToTopButton.style.display = 'block';
+              } else {
+                  backToTopButton.style.display = 'none';
+              }
+          }
+      
+          window.addEventListener('scroll', checkButtonVisibility);
+          window.addEventListener('resize', checkButtonVisibility);
+      
+          backToTopButton.addEventListener('click', function () {
+              window.scrollTo({
+                  top: 0,
+                  behavior: 'smooth' 
+              });
+          });
+          checkButtonVisibility();
+      });
+      
+        </script>
     <script src="../assets/js/vendor/jquery-1.12.4.min.js"></script>
     <script src="../assets/js/vendor/modernizr-3.7.1.min.js"></script>
     <script src="../assets/js/popper.min.js"></script>

--- a/index.html
+++ b/index.html
@@ -976,9 +976,40 @@
         </div>
       </div>
       <div id="particles-2"></div>
+      <div id="back-to-top-container">
+        <div class="circle">
+      <svg id="back-to-top" xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-arrow-up-circle-fill" viewBox="0 0 16 16">
+        <path d="M16 8A8 8 0 1 0 0 8a8 8 0 0 0 16 0m-7.5 3.5a.5.5 0 0 1-1 0V5.707L5.354 7.854a.5.5 0 1 1-.708-.708l3-3a.5.5 0 0 1 .708 0l3 3a.5.5 0 0 1-.708.708L8.5 5.707z"/>
+      </svg>
+      </div>
+      </div>
     </footer>
     <script>document.getElementById("copyright-year").textContent = new Date().getFullYear();</script>
-    <a href="#" class="back-to-top"><i class="lni-chevron-up"></i></a>
+    <script>
+      document.addEventListener("DOMContentLoaded", function () {
+          const backToTopButton = document.getElementById('back-to-top-container');
+      
+          function checkButtonVisibility() {
+              if (window.innerWidth > 100 && window.scrollY > 100) {
+                  backToTopButton.style.display = 'block';
+              } else {
+                  backToTopButton.style.display = 'none';
+              }
+          }
+      
+          window.addEventListener('scroll', checkButtonVisibility);
+          window.addEventListener('resize', checkButtonVisibility);
+      
+          backToTopButton.addEventListener('click', function () {
+              window.scrollTo({
+                  top: 0,
+                  behavior: 'smooth' 
+              });
+          });
+          checkButtonVisibility();
+      });
+      
+        </script>
     <script src="../assets/js/vendor/jquery-1.12.4.min.js"></script>
     <script src="../assets/js/vendor/modernizr-3.7.1.min.js"></script>
     <script src="../assets/js/popper.min.js"></script>

--- a/login.html
+++ b/login.html
@@ -278,9 +278,41 @@
         </div>
       </div>
       <div id="particles-2"></div>
+      <div id="particles-2"></div>
+      <div id="back-to-top-container">
+        <div class="circle">
+      <svg id="back-to-top" xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-arrow-up-circle-fill" viewBox="0 0 16 16">
+        <path d="M16 8A8 8 0 1 0 0 8a8 8 0 0 0 16 0m-7.5 3.5a.5.5 0 0 1-1 0V5.707L5.354 7.854a.5.5 0 1 1-.708-.708l3-3a.5.5 0 0 1 .708 0l3 3a.5.5 0 0 1-.708.708L8.5 5.707z"/>
+      </svg>
+      </div>
+      </div>
     </footer>
     <script>document.getElementById("copyright-year").textContent = new Date().getFullYear();</script>
-    <a href="#" class="back-to-top"><i class="lni-chevron-up"></i></a>
+    <script>
+      document.addEventListener("DOMContentLoaded", function () {
+          const backToTopButton = document.getElementById('back-to-top-container');
+      
+          function checkButtonVisibility() {
+              if (window.innerWidth > 100 && window.scrollY > 100) {
+                  backToTopButton.style.display = 'block';
+              } else {
+                  backToTopButton.style.display = 'none';
+              }
+          }
+      
+          window.addEventListener('scroll', checkButtonVisibility);
+          window.addEventListener('resize', checkButtonVisibility);
+      
+          backToTopButton.addEventListener('click', function () {
+              window.scrollTo({
+                  top: 0,
+                  behavior: 'smooth' 
+              });
+          });
+          checkButtonVisibility();
+      });
+      
+        </script>
     <script src="../assets/js/vendor/jquery-1.12.4.min.js"></script>
     <script src="../assets/js/vendor/modernizr-3.7.1.min.js"></script>
     <script src="../assets/js/popper.min.js"></script>

--- a/quiz.html
+++ b/quiz.html
@@ -374,9 +374,40 @@
         </div>
       </div>
       <div id="particles-2"></div>
+      <div id="back-to-top-container">
+        <div class="circle">
+      <svg id="back-to-top" xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-arrow-up-circle-fill" viewBox="0 0 16 16">
+        <path d="M16 8A8 8 0 1 0 0 8a8 8 0 0 0 16 0m-7.5 3.5a.5.5 0 0 1-1 0V5.707L5.354 7.854a.5.5 0 1 1-.708-.708l3-3a.5.5 0 0 1 .708 0l3 3a.5.5 0 0 1-.708.708L8.5 5.707z"/>
+      </svg>
+      </div>
+      </div>
     </footer>
     <script>document.getElementById("copyright-year").textContent = new Date().getFullYear();</script>
-    <a href="#" class="back-to-top"><i class="lni-chevron-up"></i></a>
+    <script>
+      document.addEventListener("DOMContentLoaded", function () {
+          const backToTopButton = document.getElementById('back-to-top-container');
+      
+          function checkButtonVisibility() {
+              if (window.innerWidth > 100 && window.scrollY > 100) {
+                  backToTopButton.style.display = 'block';
+              } else {
+                  backToTopButton.style.display = 'none';
+              }
+          }
+      
+          window.addEventListener('scroll', checkButtonVisibility);
+          window.addEventListener('resize', checkButtonVisibility);
+      
+          backToTopButton.addEventListener('click', function () {
+              window.scrollTo({
+                  top: 0,
+                  behavior: 'smooth' 
+              });
+          });
+          checkButtonVisibility();
+      });
+      
+        </script>
     <script src="../assets/js/vendor/jquery-1.12.4.min.js"></script>
     <script src="../assets/js/vendor/modernizr-3.7.1.min.js"></script>
     <script src="../assets/js/popper.min.js"></script>

--- a/tools/sip.html
+++ b/tools/sip.html
@@ -368,8 +368,39 @@
       </div>
     </div>
     <div id="particles-2"></div>
+    <div id="back-to-top-container">
+      <div class="circle">
+    <svg id="back-to-top" xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-arrow-up-circle-fill" viewBox="0 0 16 16">
+      <path d="M16 8A8 8 0 1 0 0 8a8 8 0 0 0 16 0m-7.5 3.5a.5.5 0 0 1-1 0V5.707L5.354 7.854a.5.5 0 1 1-.708-.708l3-3a.5.5 0 0 1 .708 0l3 3a.5.5 0 0 1-.708.708L8.5 5.707z"/>
+    </svg>
+    </div>
+    </div>
   </footer>
-  <a href="#" class="back-to-top"><i class="lni-chevron-up"></i></a>
+  <script>
+    document.addEventListener("DOMContentLoaded", function () {
+        const backToTopButton = document.getElementById('back-to-top-container');
+    
+        function checkButtonVisibility() {
+            if (window.innerWidth > 100 && window.scrollY > 100) {
+                backToTopButton.style.display = 'block';
+            } else {
+                backToTopButton.style.display = 'none';
+            }
+        }
+    
+        window.addEventListener('scroll', checkButtonVisibility);
+        window.addEventListener('resize', checkButtonVisibility);
+    
+        backToTopButton.addEventListener('click', function () {
+            window.scrollTo({
+                top: 0,
+                behavior: 'smooth' 
+            });
+        });
+        checkButtonVisibility();
+    });
+    
+      </script>
   <script src="../assets/js/vendor/jquery-1.12.4.min.js"></script>
   <script src="../assets/js/vendor/modernizr-3.7.1.min.js"></script>
   <script src="../assets/js/popper.min.js"></script>

--- a/trends.html
+++ b/trends.html
@@ -423,9 +423,40 @@
         </div>
       </div>
       <div id="particles-2"></div>
+      <div id="back-to-top-container">
+        <div class="circle">
+      <svg id="back-to-top" xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-arrow-up-circle-fill" viewBox="0 0 16 16">
+        <path d="M16 8A8 8 0 1 0 0 8a8 8 0 0 0 16 0m-7.5 3.5a.5.5 0 0 1-1 0V5.707L5.354 7.854a.5.5 0 1 1-.708-.708l3-3a.5.5 0 0 1 .708 0l3 3a.5.5 0 0 1-.708.708L8.5 5.707z"/>
+      </svg>
+      </div>
+      </div>
     </footer>
     <script>document.getElementById("copyright-year").textContent = new Date().getFullYear();</script>
-    <a href="#" class="back-to-top"><i class="lni-chevron-up"></i></a>
+    <script>
+      document.addEventListener("DOMContentLoaded", function () {
+          const backToTopButton = document.getElementById('back-to-top-container');
+      
+          function checkButtonVisibility() {
+              if (window.innerWidth > 100 && window.scrollY > 100) {
+                  backToTopButton.style.display = 'block';
+              } else {
+                  backToTopButton.style.display = 'none';
+              }
+          }
+      
+          window.addEventListener('scroll', checkButtonVisibility);
+          window.addEventListener('resize', checkButtonVisibility);
+      
+          backToTopButton.addEventListener('click', function () {
+              window.scrollTo({
+                  top: 0,
+                  behavior: 'smooth' 
+              });
+          });
+          checkButtonVisibility();
+      });
+      
+        </script>
     <script src="../assets/js/vendor/jquery-1.12.4.min.js"></script>
     <script src="../assets/js/vendor/modernizr-3.7.1.min.js"></script>
     <script src="../assets/js/popper.min.js"></script>


### PR DESCRIPTION
#179 added.
I have added the smooth transition button which takes you to the top of the website. There are some hover effects also and it appears when the screen size is greater than 100. I have added back to top button to the pages like home, blog, quiz, tools and login sections.
Home section:
![Screenshot 2024-05-24 205148](https://github.com/ayush-that/FinVeda/assets/130165687/39ceb466-3752-4d00-ba52-9b2a3b249555)
![Screenshot 2024-05-24 205203](https://github.com/ayush-that/FinVeda/assets/130165687/d56f7caa-614b-4a1a-ad57-3754611023ca)
![Screenshot 2024-05-24 205215](https://github.com/ayush-that/FinVeda/assets/130165687/94bfae7c-7da9-40a3-b151-a0b2459c8067)
Trends, blogs, quiz, tools, login sections:
![image](https://github.com/ayush-that/FinVeda/assets/130165687/f0f69fc1-cfb7-43d7-b557-94230a3a01bb)
