### PR TITLE
Fixed the unequal height issue of Testimonial Boxes in the User Experience Section!

### DIFF
--- a/assets/css/slick.css
+++ b/assets/css/slick.css
@@ -85,7 +85,7 @@
   pointer-events: none;
 }
 .slick-initialized .slick-slide {
-  display: block;
+  display: flex;
 }
 .slick-loading .slick-slide {
   visibility: hidden;

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1607,7 +1607,10 @@ p {
   border-radius: 10px;
   padding: 25px 30px 5px;
   border-radius: 10px;
-  border: 2px solid transparent;
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  border: 1px solid transparent;
   margin: 30px 0;
   -webkit-transition: all 0.3s ease-out 0s;
   -moz-transition: all 0.3s ease-out 0s;


### PR DESCRIPTION
# Description
This pull request addresses the issue where the testimonial boxes on the _Home Page_ of "_Users Sharing their Experiences_" section had different heights due to varying content lengths. Now all the boxes have same height which gives a clean and consistent layout.

### **Issue Number:** #229 

# Attachments:
**_(Before)_**

![Screenshot (25)](https://github.com/ayush-that/FinVeda/assets/169380578/ff750a51-a9a0-4b39-8bd4-59d406cd853f)

(**After**)

![Screenshot (58)](https://github.com/ayush-that/FinVeda/assets/169380578/88306ce3-1900-4fea-bc08-2b6881554055)
