### PR TITLE
Fixed Typo in Footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -769,7 +769,7 @@
             <div class="footer-link d-flex mt-50 justify-content-md-between">
               <div class="link-wrapper wow fadeIn" data-wow-duration="1s" data-wow-delay="0.4s">
                 <div class="footer-title">
-                  <h4 class="title">Quick Link</h4>
+                  <h4 class="title">Quick Links</h4>
                 </div>
                 <ul class="link">
                   <li><a href="./blogs/privacy-policy.html">Privacy Policy</a></li>


### PR DESCRIPTION
The Typing error in footer has been fixed.
The _Quick Link_ has been changed to _Quick Links_.

Here's how it looked before,
![image](https://github.com/ayush-that/FinVeda/assets/169376061/01ad0018-194e-4846-a103-78d0241dc916)

And here's how it looks now,
![image](https://github.com/ayush-that/FinVeda/assets/169376061/f5ac84b9-76e1-4cd9-8fd0-ab6d82e95f1f)

Issue Number:
#337 Fixed 

Thank You for assigning me this issue. Please add suitable labels to this PR.