### PR TITLE
made MFI and EMI calculators on tools page responsive at mobile view.

### DIFF
--- a/tools/sip.html
+++ b/tools/sip.html
@@ -230,8 +230,8 @@
         </button>
       </div>
       <br />
-      <div style="display: flex;">
-        <div class="result"><b>Result :</b></div>
+      <div style="display: flex; justify-content: flex-start; font-size: medium;" class="result"><b>Result :</b></div>
+      <div style="display: flex; justify-content: center;">
         <div class="result-container">
           <div>Monthly Investment for <span id="mode-1">SIP</span></div>
           <div><span>Rs.</span>&nbsp;<span id="input-1"></span></div>
@@ -252,7 +252,7 @@
           <div>Maturity Value</div>
           <div><span id="currency-change-3">Rs.</span>&nbsp;<span id="maturity-value"></span></div>
         </div>
-      </div>
+    </div>
     </div>
     <!-- EMI Calculator -->
     <script src="emiCalculator.js"></script>
@@ -277,8 +277,8 @@
         <button class="btn btn-success" type="button" onclick="calculateEMI()">Calculate EMI</button>
       </div>
       <br />
+       <div class="result" style="display: flex; justify-content: flex-start; font-size: medium;"><b>Result :</b></div>
       <div style="display: flex;">
-        <div class="result"><b>Result :</b></div>
         <div class="result-container">
           <div>Monthly EMI</div>
           <div><span id="monthlyEMI"></span></div>


### PR DESCRIPTION
Fixes #491 
made the following calculators responsive in mobile view.
![image](https://github.com/user-attachments/assets/5b7eda70-5941-47b6-9dcd-fb219bbf7d5c)
![Screenshot 2024-07-16 082658](https://github.com/user-attachments/assets/8817d0e0-44ae-4045-b809-653a783fc1d4)
