### PR TITLE
Added Resource Section Footer Links in Missing Pages Footer 

### DIFF
--- a/Licensing.html
+++ b/Licensing.html
@@ -363,9 +363,11 @@
                     <h4 class="title">Resources</h4>
                   </div>
                   <ul class="link">
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../login.html">Page</a></li>
-                    <li><a href="../blog.html">Blog</a></li>
+                    <li><a href="./index.html">Home</a></li>
+                    <li><a href="./trends.html">Trends</a></li>
+                    <li><a href="./tools/sip.html">Tools</a></li>
+                    <li><a href="./blog.html">Blog</a></li>
+                    <li><a href="./quiz.html">Quiz</a></li>
                   </ul>
                 </div>
               </div>

--- a/blogs/privacy-policy.html
+++ b/blogs/privacy-policy.html
@@ -325,9 +325,11 @@
                     <h4 class="title">Resources</h4>
                   </div>
                   <ul class="link">
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="../login.html">Page</a></li>
-                    <li><a href="../blog.html">Blog</a></li>
+                    <li><a href="./index.html">Home</a></li>
+                    <li><a href="./trends.html">Trends</a></li>
+                    <li><a href="./tools/sip.html">Tools</a></li>
+                    <li><a href="./blog.html">Blog</a></li>
+                    <li><a href="./quiz.html">Quiz</a></li>
                   </ul>
                 </div>
               </div>

--- a/blogs/refund-policy.html
+++ b/blogs/refund-policy.html
@@ -208,9 +208,11 @@
                   <h4 class="title">Resources</h4>
                 </div>
                 <ul class="link">
-                  <li><a href="../index.html">Home</a></li>
-                  <li><a href="../login.html">Page</a></li>
-                  <li><a href="../blog.html">Blog</a></li>
+                  <li><a href="./index.html">Home</a></li>
+                  <li><a href="./trends.html">Trends</a></li>
+                  <li><a href="./tools/sip.html">Tools</a></li>
+                  <li><a href="./blog.html">Blog</a></li>
+                  <li><a href="./quiz.html">Quiz</a></li>
                 </ul>
               </div>
             </div>

--- a/blogs/terms-of-service.html
+++ b/blogs/terms-of-service.html
@@ -268,9 +268,11 @@
                   <h4 class="title">Resources</h4>
                 </div>
                 <ul class="link">
-                  <li><a href="../index.html">Home</a></li>
-                  <li><a href="../login.html">Page</a></li>
-                  <li><a href="../blog.html">Blog</a></li>
+                  <li><a href="./index.html">Home</a></li>
+                  <li><a href="./trends.html">Trends</a></li>
+                  <li><a href="./tools/sip.html">Tools</a></li>
+                  <li><a href="./blog.html">Blog</a></li>
+                  <li><a href="./quiz.html">Quiz</a></li>
                 </ul>
               </div>
             </div>

--- a/tools/sip.html
+++ b/tools/sip.html
@@ -600,9 +600,11 @@
                   <h4 class="title">Resources</h4>
                 </div>
                 <ul class="link">
-                  <li><a href="../index.html">Home</a></li>
-                  <li><a href="../login.html">Page</a></li>
-                  <li><a href="../blog.html">Blog</a></li>
+                  <li><a href="./index.html">Home</a></li>
+                  <li><a href="./trends.html">Trends</a></li>
+                  <li><a href="./tools/sip.html">Tools</a></li>
+                  <li><a href="./blog.html">Blog</a></li>
+                  <li><a href="./quiz.html">Quiz</a></li>
                 </ul>
               </div>
             </div>


### PR DESCRIPTION
Hey @ayush-that  @deepeshmlgupta and @Agarwalvidu  issue closes #425 

I have added resource section footer links in missing pages footer
- Tools Page
- Privacy Policy Page
- Terms and Conditions Page
- Licensing Page
- Cookies Policy Page

![image](https://github.com/user-attachments/assets/59955c96-815a-42a1-bf53-73e0dede0aa2)

Take a look and review this PR
 