### PR TITLE
Fixed The Feedback Button is not Overlapping Behind The Footer #535

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -2389,6 +2389,7 @@ p {
   align-items: center;
   opacity: 0.4;
   transition: 500ms;
+  z-index: 9999;
 }
 
 #CommentBtn:hover {


### PR DESCRIPTION
Hey @ayush-that, @deepeshmlgupta and @Agarwalvidu  issue closes #535 

I have fixed the overlapping of the feedback button behind the footer

![image](https://github.com/user-attachments/assets/9a0a4f31-1be1-4161-bb17-98c1418cb62f)


Please take a look and review it.