### PR TITLE
Fixed repetition of the 'About Us' button in the navbar

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -199,11 +199,8 @@
                     <li class="nav-item">
                       <a class="page-scroll" href="./index.html">Home 🏡</a>
                     </li>
-                    <li class="nav-item active">
-                    <a class="page-scroll" href="./about.html">About us </a>
-                  </li>
                     <li class="nav-item">
-                      <a class="page-scroll" href="./about.html" id="active-page">About us </a>
+                      <a class="page-scroll" href="./about.html">About us </a>
                     </li>
                     <li class="nav-item">
                       <a class="page-scroll" href="./trends.html">Trends 📈</a>

--- a/quiz.html
+++ b/quiz.html
@@ -174,7 +174,7 @@
                   <li class="nav-item">
                     <a class="page-scroll" href="./index.html">Home 🏡</a>
                   </li>
-                  <li class="nav-item active">
+                  <li class="nav-item">
                     <a class="page-scroll" href="./about.html">About us </a>
                   </li>
                   <li class="nav-item">
@@ -186,7 +186,7 @@
                   <li class="nav-item">
                     <a class="page-scroll" href="./blog.html">Blogs 📰</a>
                   </li>
-                  <li class="nav-item">
+                  <li class="nav-item active">
                     <a class="page-scroll" href="./quiz.html" id="active-page">Quiz 🤔</a>
                   </li>
                   <li class="nav-item">

--- a/tools/sip.html
+++ b/tools/sip.html
@@ -175,9 +175,6 @@
                   <li class="nav-item">
                     <a class="page-scroll" href="../index.html">Home 🏡</a>
                   </li>
-                  <li class="nav-item active">
-                    <a class="page-scroll" href="/about.html">About us </a>
-                  </li>
                   <li class="nav-item">
                       <a class="page-scroll" href="/about.html">About us </a>
                   </li>

--- a/trends.html
+++ b/trends.html
@@ -231,9 +231,6 @@
                     <a class="page-scroll" href="./about.html">About us </a>
                   </li>
                   <li class="nav-item active">
-                    <a class="page-scroll" href="./about.html">About us </a>
-                  </li>
-                  <li class="nav-item active">
                     <a class="page-scroll" href="./trends.html" id="active-page">Trends 📈</a>
                   </li>
                   <li class="nav-item">


### PR DESCRIPTION
Issue #611 solved

Removed the redundant 'About Us' button instances in the blogs, trends and tools page. 

![image](https://github.com/user-attachments/assets/356f3e28-245a-4ed6-96f3-94203a6fcb12)
![image](https://github.com/user-attachments/assets/3f3255db-c98b-4b2c-b4f3-d2ae11885214)
![image](https://github.com/user-attachments/assets/5a30f937-1dd1-4204-9b19-ddfa1ad8b8a3)
