### PR TITLE
Fixed double underline on Navbar Hover on Licensing Page 

### DIFF
--- a/Licensing.html
+++ b/Licensing.html
@@ -218,7 +218,7 @@
                     <li class="nav-item">
                       <a class="page-scroll" href="./index.html">Home 🏡</a>
                     </li>
-                    <li class="nav-item active">
+                    <li class="nav-item">
                       <a class="page-scroll" href="./about.html">About Us 📖</a>
                     </li>    
                     <li class="nav-item">

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -696,6 +696,14 @@ p {
   width: 100%;
 }
 
+.navbar-nav .nav-item a {
+  text-decoration: none !important;
+}
+
+.navbar-nav .nav-item a:hover {
+  text-decoration: none !important;
+}
+
 #active-page::after {
   width: 100%;
 }


### PR DESCRIPTION
### Issue Fixed:
Fixes #718

### Description:
Fixed double underline on Navbar Hover on Licensing Page.

### Screenshot:
Before:
![Screenshot 2024-07-26 165420](https://github.com/user-attachments/assets/2df45234-8dbf-4a4e-9991-3652b38597fd)

After:
https://github.com/user-attachments/assets/3e82ca2a-92b2-48a8-8f1c-21703282a4ee
