### PR TITLE
Fixed Unwanted Bullet Points in Footer on Licensing Page

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -2235,6 +2235,10 @@ p {
   padding: 0 0px;
 }
 
+.link {
+  list-style: none;
+}
+
 .contact-sec {
   padding: 30px !important;
 }


### PR DESCRIPTION
### Issue Fixed:
Fixes  #817 

### Description:
Fixed Unwanted Bullet Points in the Footer on Licensing Page.

### Screenshot:

**Before:**
![Screenshot 2024-07-31 135326](https://github.com/user-attachments/assets/0c78ff78-3dea-4e05-890b-195587ab7990)

**After:**
![Screenshot 2024-08-01 011900](https://github.com/user-attachments/assets/287a751f-54e5-4e72-8148-8ea23235a204)
