### PR TITLE
Fixed Inconsistent Footer Design on 'Licensing' Page

### DIFF
--- a/Licensing.html
+++ b/Licensing.html
@@ -513,7 +513,7 @@
                   <div class="footer-title">
                     <h4 class="title">Quick Link</h4>
                   </div>
-                  <ul class="link">
+                  <ul class="link" style="list-style-type: none; margin-left: 3px;">
                     <li><a href="/blogs/privacy-policy.html">Privacy Policy</a></li>
                     <li><a href="/blogs/refund-policy.html">Refund Policy</a></li>
                     <li><a href="Licensing.html">Licensing</a></li>
@@ -529,7 +529,7 @@
                   <div class="footer-title">
                     <h4 class="title">Resources</h4>
                   </div>
-                  <ul class="link">
+                  <ul class="link" style="list-style-type: none; margin-left: 3px;">
                     <li><a href="./index.html">Home</a></li>
                     <li><a href="/about.html">About Us</a></li>
                     <li><a href="./trends.html">Trends</a></li>
@@ -549,7 +549,7 @@
                 <div class="footer-title">
                   <h4 class="title">Contact Us</h4>
                 </div>
-                <ul class="contact custom-margin">
+                <ul class="contact custom-margin" style="list-style-type: none; margin-left: 3px;">
                   <li class="d-sm-flex justify-content-center">
                     <i class="fa fa-envelope d-sm-flex align-items-center white" style="font: size 16px; width: 10%;"></i>
                     <p style="width: 80%;">


### PR DESCRIPTION
Issue #790 solved

Removed the bullet points next to the content of the 'Licensing' page footer.

Before: 
![image](https://github.com/user-attachments/assets/50edcaa8-2dfa-4637-a7c6-03af613e8fb3)

After:
![Screenshot 2024-08-01 064751](https://github.com/user-attachments/assets/e2ddb5d4-e0e3-412c-836d-1dc6427fa160)
