### PR TITLE
Added Location Icon in Footer

### DIFF
--- a/blogs/privacy-policy.html
+++ b/blogs/privacy-policy.html
@@ -19,6 +19,7 @@
     <link rel="stylesheet" href="../assets/css/default.css" />
     <link rel="stylesheet" href="../assets/css/style.css" />
     <link rel="stylesheet" href="../assets/css/popup.css" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" />
     <style>
       #progressBar {
       position: fixed;

--- a/blogs/refund-policy.html
+++ b/blogs/refund-policy.html
@@ -16,6 +16,7 @@
   <link rel="stylesheet" href="../assets/css/default.css" />
   <link rel="stylesheet" href="../assets/css/style.css" />
   <link rel="stylesheet" href="../assets/css/popup.css" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" />
 
   <style>
     #progressBar {

--- a/blogs/terms-of-service.html
+++ b/blogs/terms-of-service.html
@@ -16,6 +16,7 @@
   <link rel="stylesheet" href="../assets/css/default.css" />
   <link rel="stylesheet" href="../assets/css/style.css" />
   <link rel="stylesheet" href="../assets/css/popup.css" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" />
 
 
   <style>

--- a/contributors.html
+++ b/contributors.html
@@ -17,6 +17,7 @@
   <link rel="stylesheet" href="../assets/css/default.css" />
   <link rel="stylesheet" href="../assets/css/style.css" />
   <link rel="stylesheet" href="../assets/css/popup.css" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" />
   <style>
     * {
       cursor: url('/assets/images/ads_click_24dp_000000_FILL0_wght400_GRAD0_opsz24.svg'), auto;


### PR DESCRIPTION
Issue #792 solved

Added the location icon in the footer of 'Privacy Policy', 'Refund Policy', 'Terms of Service' and 'Our Contributers' page to make it consistent with other pages.

Before: 
![Screenshot 2024-08-02 014724](https://github.com/user-attachments/assets/c851833e-cade-45a8-a457-e7008d61c925)

After: 
![image](https://github.com/user-attachments/assets/9a746efe-9e1a-49f8-a182-17c2e111c257)
