### PR TITLE
Fixed Overlapping Cards on About Us Page in Mobile View

### DIFF
--- a/assets/css/about.css
+++ b/assets/css/about.css
@@ -1,6 +1,10 @@
+:root{
+    --slider-dark:rgba(7, 97, 233, 0.808);
+}
+
 .main{
     width: 100%;
-    height: 500px;
+    height: auto;
     text-align: center;
     position: relative;
     top: 0;
@@ -8,15 +12,11 @@
     /* border: 2px solid saddlebrown; */
 }
 
-:root{
-    --slider-dark:rgba(7, 97, 233, 0.808);
-}
-
 .card{
     /* border: 2px solid salmon; */
     height: max-content;
     text-align: center;
-    padding: 10px 10px;
+    padding: 10px; 
     font-size: 25px;
     font-weight: 500;
     width: 100%;
@@ -32,7 +32,7 @@
     background: white;
     padding: 30px;
     border-radius: 10px;
-    position: absolute;
+    position: relative;
     /* bottom: 0; */
     box-shadow: 0 0 20px -15px black;
     z-index: 2;
@@ -41,10 +41,18 @@
 
 .row-card{
     display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
     /* border: 2px solid saddlebrown; */
+    /* height: fit-content; */
 }
 
-
+.col-md-4 {
+    flex: 0 0 30%;
+    max-width: 30%;
+    box-sizing: border-box;
+    padding: 10px;
+}
 
 .service-logo img{
     height: 150px;
@@ -57,7 +65,7 @@
     width: 80%;
     /* border: 2px solid salmon; */
     position: absolute;
-    bottom: 25px;
+    bottom: 0px;
     left: 10%;
     box-shadow: 0 0 20px -15px black;
     transition: transform .7s;
@@ -78,7 +86,7 @@
     width: 64%;
     /* border: 2px solid salmon; */
     position: absolute;
-    bottom: 25px;
+    bottom: 0px;
     left: 18%;
     box-shadow: 0 0 20px -15px black;
     transition: transform .7s;
@@ -178,6 +186,27 @@
     visibility: hidden;
 }
 
+@media (max-width: 390px) {
+    /* .row-card{
+        gap: 330px; 
+        margin-top: 20px;
+    } */
+    /* .card{
+        height: 2530px;
+    } */
+    .card h2 {
+        font-size: 18px;
+        margin-bottom: 20px;
+    }
+    .service h4 {
+        font-size: 16px;
+    }
+
+    .service p {
+        font-size: 14px;
+    }
+}
+
 @media (max-width: 768px) {
     .card h2 {
         font-size: 20px;
@@ -186,7 +215,13 @@
 
     .row-card {
         flex-direction: column; 
-        gap: 20px;
+        /* gap: 20px; */
+    }
+
+    .col-md-4 {
+        flex: 0 0 100%;
+        max-width: 100%;
+        padding: 10px 0;
     }
 
     .service {


### PR DESCRIPTION
Issue #837 solved

Made the about us page mobile responsive and fixed the overlapping cards problem.

![Screenshot 2024-08-02 221553](https://github.com/user-attachments/assets/427b9a43-f061-44eb-a434-8462426df781)
![Screenshot 2024-08-02 221600](https://github.com/user-attachments/assets/407bd21e-a36d-40a7-9fcf-f61f6ebed490)
