### PR TITLE
title of login/register-FinVeda

### DIFF
--- a/about.html
+++ b/about.html
@@ -707,6 +707,53 @@
       registerModal.style.display = 'none';
     }
   }
+  function openModal() {
+    var modal = document.getElementById("myModal");
+    modal.style.display = "block";
+    document.title = "Login/Register - FinVeda";  // Update the title when modal is opened
+  }
+
+  function closeModal() {
+    var modal = document.getElementById("myModal");
+    modal.style.display = "none";
+    document.title = "FinVeda";  // Revert the title back when modal is closed
+  }
+
+  window.onclick = function (event) {
+    var modal = document.getElementById("myModal");
+    if (event.target == modal) {
+      closeModal(); // Call closeModal function
+    }
+  };
+
+  document.addEventListener("DOMContentLoaded", function () {
+    const registerModal = document.getElementById("registerModal");
+    const loginModal = document.getElementById("myModal");
+    const registerLink = document.getElementById("registerLink");
+    const loginLink = document.getElementById("loginLink");
+
+    // Event listener for the register link
+    registerLink.addEventListener("click", function (event) {
+      event.preventDefault();
+      loginModal.style.display = "none";
+      registerModal.style.display = "block";
+      document.title = "Login/Register - FinVeda";  // Update title when registering
+    });
+
+    // Event listener for the login link
+    loginLink.addEventListener("click", function (event) {
+      event.preventDefault();
+      registerModal.style.display = "none";
+      loginModal.style.display = "block";
+      document.title = "Login/Register - FinVeda";  // Update title when logging in
+    });
+
+    // Close button event listeners for modals
+    registerModal.querySelector(".close").addEventListener("click", closeModal);
+    loginModal.querySelector(".close").addEventListener("click", closeModal);
+  });
+
+
 </script>
 <script src="./tools/smoothScroll.js"></script>
 <script defer src="./assets/js/arthsathi-style.js"></script>

--- a/blog.html
+++ b/blog.html
@@ -949,6 +949,53 @@
           registerModal.style.display = "none";
         }
       };
+      function openModal() {
+    var modal = document.getElementById("myModal");
+    modal.style.display = "block";
+    document.title = "Login/Register - FinVeda";  // Update the title when modal is opened
+  }
+
+  function closeModal() {
+    var modal = document.getElementById("myModal");
+    modal.style.display = "none";
+    document.title = "FinVeda";  // Revert the title back when modal is closed
+  }
+
+  window.onclick = function (event) {
+    var modal = document.getElementById("myModal");
+    if (event.target == modal) {
+      closeModal(); // Call closeModal function
+    }
+  };
+
+  document.addEventListener("DOMContentLoaded", function () {
+    const registerModal = document.getElementById("registerModal");
+    const loginModal = document.getElementById("myModal");
+    const registerLink = document.getElementById("registerLink");
+    const loginLink = document.getElementById("loginLink");
+
+    // Event listener for the register link
+    registerLink.addEventListener("click", function (event) {
+      event.preventDefault();
+      loginModal.style.display = "none";
+      registerModal.style.display = "block";
+      document.title = "Login/Register - FinVeda";  // Update title when registering
+    });
+
+    // Event listener for the login link
+    loginLink.addEventListener("click", function (event) {
+      event.preventDefault();
+      registerModal.style.display = "none";
+      loginModal.style.display = "block";
+      document.title = "Login/Register - FinVeda";  // Update title when logging in
+    });
+
+    // Close button event listeners for modals
+    registerModal.querySelector(".close").addEventListener("click", closeModal);
+    loginModal.querySelector(".close").addEventListener("click", closeModal);
+  });
+
+
     </script>
     <script src="./tools/smoothScroll.js"></script>
   </body>

--- a/contributors.html
+++ b/contributors.html
@@ -5,6 +5,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Contributors - FinVeda</title>
+  
   <link rel="shortcut icon" href="./assets/images/favicon2.png" type="image/png" />
   <link rel="stylesheet" href="./assets/css/contributors.css">
   <script src="https://kit.fontawesome.com/a076d05399.js" crossorigin="anonymous"></script>

--- a/index.html
+++ b/index.html
@@ -1888,7 +1888,51 @@ function getPrevId(currentId) {
         }, 500); // Matches animation duration
     });
 });
+function openModal() {
+    var modal = document.getElementById("myModal");
+    modal.style.display = "block";
+    document.title = "Login/Register - FinVeda";  // Update the title when modal is opened
+  }
 
+  function closeModal() {
+    var modal = document.getElementById("myModal");
+    modal.style.display = "none";
+    document.title = "FinVeda";  // Revert the title back when modal is closed
+  }
+
+  window.onclick = function (event) {
+    var modal = document.getElementById("myModal");
+    if (event.target == modal) {
+      closeModal(); // Call closeModal function
+    }
+  };
+
+  document.addEventListener("DOMContentLoaded", function () {
+    const registerModal = document.getElementById("registerModal");
+    const loginModal = document.getElementById("myModal");
+    const registerLink = document.getElementById("registerLink");
+    const loginLink = document.getElementById("loginLink");
+
+    // Event listener for the register link
+    registerLink.addEventListener("click", function (event) {
+      event.preventDefault();
+      loginModal.style.display = "none";
+      registerModal.style.display = "block";
+      document.title = "Login/Register - FinVeda";  // Update title when registering
+    });
+
+    // Event listener for the login link
+    loginLink.addEventListener("click", function (event) {
+      event.preventDefault();
+      registerModal.style.display = "none";
+      loginModal.style.display = "block";
+      document.title = "Login/Register - FinVeda";  // Update title when logging in
+    });
+
+    // Close button event listeners for modals
+    registerModal.querySelector(".close").addEventListener("click", closeModal);
+    loginModal.querySelector(".close").addEventListener("click", closeModal);
+  });
   </script>
 
 </body>

--- a/quiz.html
+++ b/quiz.html
@@ -754,6 +754,53 @@
       registerModal.style.display = 'none';
     }
   }
+  function openModal() {
+    var modal = document.getElementById("myModal");
+    modal.style.display = "block";
+    document.title = "Login/Register - FinVeda";  // Update the title when modal is opened
+  }
+
+  function closeModal() {
+    var modal = document.getElementById("myModal");
+    modal.style.display = "none";
+    document.title = "FinVeda";  // Revert the title back when modal is closed
+  }
+
+  window.onclick = function (event) {
+    var modal = document.getElementById("myModal");
+    if (event.target == modal) {
+      closeModal(); // Call closeModal function
+    }
+  };
+
+  document.addEventListener("DOMContentLoaded", function () {
+    const registerModal = document.getElementById("registerModal");
+    const loginModal = document.getElementById("myModal");
+    const registerLink = document.getElementById("registerLink");
+    const loginLink = document.getElementById("loginLink");
+
+    // Event listener for the register link
+    registerLink.addEventListener("click", function (event) {
+      event.preventDefault();
+      loginModal.style.display = "none";
+      registerModal.style.display = "block";
+      document.title = "Login/Register - FinVeda";  // Update title when registering
+    });
+
+    // Event listener for the login link
+    loginLink.addEventListener("click", function (event) {
+      event.preventDefault();
+      registerModal.style.display = "none";
+      loginModal.style.display = "block";
+      document.title = "Login/Register - FinVeda";  // Update title when logging in
+    });
+
+    // Close button event listeners for modals
+    registerModal.querySelector(".close").addEventListener("click", closeModal);
+    loginModal.querySelector(".close").addEventListener("click", closeModal);
+  });
+
+
 </script>
 <script src="./tools/smoothScroll.js"></script>
 </body>

--- a/tools/sip.html
+++ b/tools/sip.html
@@ -1623,6 +1623,53 @@
         registerModal.style.display = 'none';
       }
     }
+    function openModal() {
+    var modal = document.getElementById("myModal");
+    modal.style.display = "block";
+    document.title = "Login/Register - FinVeda";  // Update the title when modal is opened
+  }
+
+  function closeModal() {
+    var modal = document.getElementById("myModal");
+    modal.style.display = "none";
+    document.title = "FinVeda";  // Revert the title back when modal is closed
+  }
+
+  window.onclick = function (event) {
+    var modal = document.getElementById("myModal");
+    if (event.target == modal) {
+      closeModal(); // Call closeModal function
+    }
+  };
+
+  document.addEventListener("DOMContentLoaded", function () {
+    const registerModal = document.getElementById("registerModal");
+    const loginModal = document.getElementById("myModal");
+    const registerLink = document.getElementById("registerLink");
+    const loginLink = document.getElementById("loginLink");
+
+    // Event listener for the register link
+    registerLink.addEventListener("click", function (event) {
+      event.preventDefault();
+      loginModal.style.display = "none";
+      registerModal.style.display = "block";
+      document.title = "Login/Register - FinVeda";  // Update title when registering
+    });
+
+    // Event listener for the login link
+    loginLink.addEventListener("click", function (event) {
+      event.preventDefault();
+      registerModal.style.display = "none";
+      loginModal.style.display = "block";
+      document.title = "Login/Register - FinVeda";  // Update title when logging in
+    });
+
+    // Close button event listeners for modals
+    registerModal.querySelector(".close").addEventListener("click", closeModal);
+    loginModal.querySelector(".close").addEventListener("click", closeModal);
+  });
+
+
   </script>
   <script src="./smoothScroll.js"></script>
 </body>

--- a/trends.html
+++ b/trends.html
@@ -757,6 +757,51 @@
         registerModal.style.display = 'none';
       }
     }
+    function openModal() {
+    var modal = document.getElementById("myModal");
+    modal.style.display = "block";
+    document.title = "Login/Register - FinVeda";  // Update the title when modal is opened
+  }
+
+  function closeModal() {
+    var modal = document.getElementById("myModal");
+    modal.style.display = "none";
+    document.title = "FinVeda";  // Revert the title back when modal is closed
+  }
+
+  window.onclick = function (event) {
+    var modal = document.getElementById("myModal");
+    if (event.target == modal) {
+      closeModal(); // Call closeModal function
+    }
+  };
+
+  document.addEventListener("DOMContentLoaded", function () {
+    const registerModal = document.getElementById("registerModal");
+    const loginModal = document.getElementById("myModal");
+    const registerLink = document.getElementById("registerLink");
+    const loginLink = document.getElementById("loginLink");
+
+    // Event listener for the register link
+    registerLink.addEventListener("click", function (event) {
+      event.preventDefault();
+      loginModal.style.display = "none";
+      registerModal.style.display = "block";
+      document.title = "Login/Register - FinVeda";  // Update title when registering
+    });
+
+    // Event listener for the login link
+    loginLink.addEventListener("click", function (event) {
+      event.preventDefault();
+      registerModal.style.display = "none";
+      loginModal.style.display = "block";
+      document.title = "Login/Register - FinVeda";  // Update title when logging in
+    });
+
+    // Close button event listeners for modals
+    registerModal.querySelector(".close").addEventListener("click", closeModal);
+    loginModal.querySelector(".close").addEventListener("click", closeModal);
+  });
   </script>
   <script src="./tools/smoothScroll.js"></script>
 </body>


### PR DESCRIPTION
Title Update Feature for Login/Register Modal
I have successfully enhanced the user experience by implementing functionality that changes the browser title to "Login/Register - FinVeda" whenever the login modal is triggered. This improvement ensures consistency across the application, as the title now updates not only when accessing the modal from the home page but also from various other pages, including:

About Us Page
Quiz Page
Tools Page
Trends Page
Blogs Page
This feature provides clarity to users, indicating that they are in the login/register context regardless of their current page, enhancing overall navigation and usability.

## Related Issue
[Cite any related issue(s) this pull request addresses. If none, simply state “None”]

## Description
[Please include a brief description of the changes or features added]

## Type of PR

- [x] Bug fix
- [x] Feature enhancement
- [x] Documentation update
- [x] Other (specify): _______________

## Screenshots / videos (if applicable)
[Attach any relevant screenshots or videos demonstrating the changes]

## Checklist:
- [x] I have performed a self-review of my code
- [x] I have read and followed the Contribution Guidelines.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [x] I have commented my code, particularly in hard-to-understand areas.
<!-- [X] - put a cross/X inside [] to check the box -->

## Additional context:
[Include any additional information or context that might be helpful for reviewers.]
