### PR TITLE
Removed excessive space between icons and related text for contact and career pages

### DIFF
--- a/careers.html
+++ b/careers.html
@@ -1162,7 +1162,7 @@
                     </li>
                 
                     <li class="d-sm-flex justify-content-center" style="align-items: center; margin: 0; padding: 0; margin-bottom: 10px;">
-                        <i class="fa fa-location-dot d-sm-flex align-items-center white" style="font-size: 12px; margin-right: 10px;"></i>
+                        <i class="fa fa-location-dot d-sm-flex align-items-center white" style="font-size: 12.0px; margin-right: 10px;"></i>
                         <div style="width: 100%; display: flex; align-items: center;">
                             <a href="https://www.google.com/maps/place/Delhi/@28.6436846,76.7635778,10z/data=!3m1!4b1!4m6!3m5!1s0x390cfd5b347eb62d:0x37205b715389640!8m2!3d28.7040592!4d77.1024902!16zL20vMDlmMDc?entry=ttu"
                                style="color: #fff;">

--- a/contact.html
+++ b/contact.html
@@ -1252,7 +1252,7 @@ registerCloseButton.addEventListener("click", function() {
         <div class="col-lg-3 col-md-5 col-sm-5">
           <div class="footer-contact mt-50 wow fadeIn" data-wow-duration="1s" data-wow-delay="0.8s">
               <div class="footer-title">
-                  <h4 class="title custom-margin" style="text-align: left; margin-bottom: 15px;">Contact Us</h4> <!-- Aligning heading to the left -->
+                  <h4 class="title custom-margin" style="text-align: left; margin-bottom: 15.1px;">Contact Us</h4> <!-- Aligning heading to the left -->
               </div>
                 <ul class="contact custom-margin-big" style="justify-content: space-around;">
                   


### PR DESCRIPTION
## Related Issue
I have created a pull request for issue #1259 which was assigned to me.
## Description
In the footer section of the Career page and Contact page, under the "Contact Us" section, there is an unusually large gap between the icons and their corresponding text labels. This affects the layout's visual appeal and may impact readability for users.

## Type of PR

- [x] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

## Screenshots / videos (if applicable)
![Screenshot (345)](https://github.com/user-attachments/assets/2854a79d-07d1-4f94-8b4d-f112f6124396)
![Screenshot (346)](https://github.com/user-attachments/assets/5a7e62c6-ad09-4f16-84ed-a772ee1d5f33)


## Checklist:
- [x] I have performed a self-review of my code
- [x] I have read and followed the Contribution Guidelines.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [x] I have commented my code, particularly in hard-to-understand areas.
<!-- [X] - put a cross/X inside [] to check the box -->

## Additional context:
[Include any additional information or context that might be helpful for reviewers.]
