### PR TITLE
Replace 'Back to Home' Text with Home Icon on Trend and Help Pages

### DIFF
--- a/assets/css/trends.css
+++ b/assets/css/trends.css
@@ -151,3 +151,26 @@ to {
   margin-left: auto; 
 }
   
+.home-link {
+  display: inline-block;
+  transition: background-color 0.3s, transform 0.3s; 
+  background-color: #4267B2; 
+  color: #fff; 
+  padding: 10px;
+  border-radius: 5px; 
+}
+
+.home-link:hover {
+  background-color: #fff; 
+  transform: scale(1.1); 
+  border: 1px solid #2F4F7F;
+}
+
+.home-link:hover .fa-home {
+  color: #2F4F7F; 
+}
+
+.home-link:hover .fa-home svg {
+  stroke: #2F4F7F;
+  stroke-width: 2; 
+}

--- a/faq.html
+++ b/faq.html
@@ -1,29 +1,12 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" />
   <style>
-  .back-to-home {
-    position: fixed;
-    top: 20px;
-    left: 20px;
-    z-index: 1000;
-    background-color: #007bff;
-    color: white;
-    padding: 10px 15px;
-    border-radius: 5px;
-    text-decoration: none;
-    font-weight: bold;
-    transition: background-color 0.3s;
-}
 
-.back-to-home:hover {
-    background-color: #0056b3;
-}
-</style>
+  </style>
 </head>
 <body>
-  <a href="index.html" class="back-to-home">Back to Home</a>
-
   <div class="circle-container">
     </div>
     <meta charset="UTF-8">
@@ -83,9 +66,36 @@
       .faq-icon {
         margin-left: 10px;
       }
+
+.home-link {
+    display: inline-block;
+    transition: background-color 0.3s, transform 0.3s; 
+    background-color: #4267B2; 
+    color: #fff; 
+    padding: 10px;
+    border-radius: 10px; 
+    text-decoration: none; /* Ensure no underline */
+    position: fixed; /* Fixed position */
+    top: 20px; /* Adjust as needed */
+    left: 20px; /* Adjust as needed */
+    z-index: 1000; /* Ensure it's on top of other elements */
+}
+
+    .home-link:hover {
+      background-color: #fff; 
+      transform: scale(1.1); 
+      border: 1px solid #2F4F7F;
+    }
+
+    .home-link:hover .fa-home {
+      color: #2F4F7F; 
+    }
     </style>
 </head>
 <body>
+  <a href="index.html" class="home-link">
+    <i class="fas fa-home" style="font-size: 30px;"></i>
+  </a>  
     <div class="circle-container">
         <div class="circle"></div>
         <div class="circle"></div>

--- a/trends.html
+++ b/trends.html
@@ -23,6 +23,7 @@
     <link rel="stylesheet"  href="./assets/css/trends.css"/>
     <link rel="stylesheet"  href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" />
     <link rel="stylesheet"  href="navbar.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 <body>
 
   
@@ -145,7 +146,11 @@
     </div> -->
   </header>
   <br><br><br><br>
-  <div><a href="index.html"><button style=" padding: 10px; border: none; background-color: #4267B2; color: #fff; border-radius: 10px; position: relative; left: 20px;"> Back To Home</button></a></div>
+  <div>
+    <a href="index.html" class="home-link" style="border-radius: 10px; position: relative; left: 20px; text-decoration: none;">
+        <i class="fas fa-home" style="font-size: 30px;"></i>
+    </a>
+</div>
   <div class="container"><br><br>
     <!-- TradingView Widget BEGIN -->
      <br><br>


### PR DESCRIPTION
## Related Issue
#1346 solved

## Description
To improve the user interface and make navigation more seamless, the 'Back to Home' text link has been replaced with a home icon on both the Trend and Help pages. This adjustment aligns with modern design practices, making the website more user-friendly and visually consistent. This update also helps in reducing text clutter while maintaining the functionality of redirecting users to the home page.

## Type of PR

- [ ] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

## Screenshots / videos (if applicable)


https://github.com/user-attachments/assets/4545c7a8-ed5e-4127-b04e-aeed4b40e034


## Checklist:
- [ ] I have performed a self-review of my code
- [ ] I have read and followed the Contribution Guidelines.
- [ ] I have tested the changes thoroughly before submitting this pull request.
- [ ] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [ ] I have commented my code, particularly in hard-to-understand areas.
<!-- [X] - put a cross/X inside [] to check the box -->


