### PR TITLE
Removed duplicate EMI calculator on the Tools page

### DIFF
--- a/tools/sip.html
+++ b/tools/sip.html
@@ -769,54 +769,7 @@ registerCloseButton.addEventListener("click", function() {
   </style>
   <script src="emiCalculator.js"></script>
 </head>
-<body>
-  <div class="header">
-      <h3>EMI Calculator</h3>
-      <p class="cal-content">
-          The EMI (Equated Monthly Installment) Calculator assists in calculating the monthly installment amount for a loan based on the loan amount, interest rate, and loan tenure.
-          It provides insights into the total payment and total interest paid over the loan period, helping you plan your finances better.
-      </p>
-      <div class="know-more">
-          <button class="know-more-btn" onclick="document.querySelector('.know-more-content').style.display = 'block'">Know More</button>
-          <div class="know-more-content">
-              <h6 style="text-align: left; margin: 0;">Here's how it works:</h6>
-              <ol type="1" style="font-size: 1rem; text-align: left; margin: 10px 0;">
-                  <li><b>Loan Amount</b>: Enter the principal amount of the loan.</li>
-                  <li><b>Interest Rate</b>: Specify the annual interest rate.</li>
-                  <li><b>Loan Tenure (months)</b>: Enter the loan period in months.</li>
-                  <li><b>Calculate EMI</b>: Provides the monthly EMI, total payment, and total interest.</li>
-              </ol>
-          </div>
-      </div>
-  </div>
-  <div class="page-container shadow p-5 mb-5 bg-white rounded mt-5">
-      <div class="input-container">
-          <div>
-              <div><b>Loan Amount (INR)</b></div>
-              <div><input class="form-control" id="loanAmount" type="number" placeholder="Enter loan amount" /></div>
-              <br />
-              <div><b>Interest Rate (%)</b></div>
-              <div><input class="form-control" id="interestRate" type="number" placeholder="Enter interest rate" /></div>
-              <br />
-              <div><b>Loan Tenure (Months)</b></div>
-              <div><input class="form-control" id="loanTenure" type="number" placeholder="Enter tenure in months" /></div>
-          </div>
-      </div>
-      <div class="btn-calculate">
-          <button class="btn" type="button" onclick="calculateEMI()">Calculate</button>
-          <button type="button" onclick="clearAll()" class="btn btn-secondary">Clear</button>
-      </div>
-      <div class="result">
-          <div><b>Result :</b></div>
-          <div class="result-container">
-              <div>Monthly EMI: <span id="monthlyEMI"></span></div>
-              <div>Total Payment: <span id="totalPayment"></span></div>
-              <div>Total Interest Paid: <span id="totalInterestPaid"></span></div>
-          </div>
-      </div>
-  </div>
-  <script src="emiCalculator.js" defer></script>
-</body>
+
 </html>
  
 <!DOCTYPE html>


### PR DESCRIPTION
## Related Issue
EMI Calculator Renders Twice on the Tools Page

## Description
This pull request addresses the issue of the EMI calculator rendering twice on the Tools page. The duplicate instance has been removed, ensuring that only one EMI calculator is displayed to maintain a clean and functional layout. The changes will help improve the user interface and user experience on the Tools page by eliminating redundancy.

## Type of PR

- [X] Bug fix : #1350

## Videos

https://github.com/user-attachments/assets/4e575a89-c069-4c75-b7bf-bfcde50cd5ea


## Checklist:
- [X] I have performed a self-review of my code
- [X] I have read and followed the Contribution Guidelines.
- [X] I have tested the changes thoroughly before submitting this pull request.
- [X] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [X] I have commented my code, particularly in hard-to-understand areas.
<!-- [X] - put a cross/X inside [] to check the box -->

## Additional context:
The fix ensures a streamlined user interface by keeping only one EMI calculator visible on the Tools page. This change has been tested across various browsers for consistency to ensure that the update works as expected.
