### PR TITLE
Updated Contact US portion margin 

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -2053,6 +2053,7 @@ p {
   flex: 1 1 33.333%;
   max-width: 33.333%;
   padding: 15px;
+  margin-left:1rem;
 }
 
 /* Responsive */
@@ -2305,6 +2306,7 @@ p {
     text-decoration: none;
     text-shadow: #FC0 1px 0 10px;
     color: #fff;
+    margin-left: 1rem;
 }
 h3.footer-title.custom-margin :hover{
   transform: scale(1.04);
@@ -2409,6 +2411,7 @@ h3.footer-title.custom-margin :hover{
 
 .footer-contact .contact {
   padding-top: 20px;
+  margin-left:1rem;
 }
 
 .footer-contact .contact li {


### PR DESCRIPTION
## Related Issue
#1354 


## Description
Originally the left margin was 0px ,I adjust it to some extent.

## Type of PR

- [ ] Bug fix
- [x] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

## Screenshots / videos (if applicable)
[Attach any relevant screenshots or videos demonstrating the changes]
![image](https://github.com/user-attachments/assets/5dfa4e6e-8036-41c3-a77a-af673ecb6c28)


## Checklist:
- [x] I have performed a self-review of my code
- [x] I have read and followed the Contribution Guidelines.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [x] I have commented my code, particularly in hard-to-understand areas.
<!-- [X] - put a cross/X inside [] to check the box -->

## Additional context:
I fixed 3 of them(Quick link,Resources,Contact us) in a single line which is looking more better.
