### PR TITLE
add market time with open and close status

### DIFF
--- a/assets/css/market-time.css
+++ b/assets/css/market-time.css
@@ -1,0 +1,138 @@
+/* General styling for the market status feature */
+.market-status-section-unique {
+  margin-top: 20px;
+  padding: 20px;
+  background-color: #F4F9FD;
+  border-radius: 10px;
+}
+
+.market-status-heading-unique {
+  text-align: center;
+  margin-bottom: 20px;
+  font-size: 2rem;
+  color: #333;
+}
+
+/* Scrollable container for the market status cards */
+.market-scroll-container-unique {
+  max-width: 100%;
+  max-height: 500px;
+  overflow-y: auto;
+  border: 1px solid #ccc;
+  padding: 10px;
+  background-color: #fff;
+  border-radius: 10px;
+}
+
+.market-card-container-unique {
+  display: flex;
+  flex-wrap: nowrap;
+  flex-direction: column;
+  gap: 20px;
+}
+
+/* Styling for individual market status cards */
+.market-card-unique {
+  background-color: #fff;
+  border-radius: 10px;
+  padding: 20px;
+  width: 100%;
+  box-shadow: 0 5px 15px rgba(0, 0, 0, 0.1);
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.market-status-tag-unique {
+  padding: 5px 15px;
+  border-radius: 20px;
+  font-size: 0.9rem;
+  color: #fff;
+  position: absolute;
+  top: 10px;
+  right: 10px;
+}
+
+.market-status-closed-unique {
+  background-color: #f44336;
+}
+
+.market-status-open-unique {
+  background-color: #4caf50;
+}
+
+.market-card-title-unique {
+  font-size: 1.2rem;
+  color: #333;
+  text-align: center;
+}
+
+.market-card-info-unique {
+  font-size: 1rem;
+  color: #666;
+  text-align: center;
+}
+
+.market-card-notes-unique {
+  font-size: 0.9rem;
+  color: #888;
+  margin-top: 10px;
+}
+
+
+/* Responsive design for market status feature */
+@media (min-width: 1024px) and (min-width: 768px) {
+  .market-status-section-unique {
+    padding-left: 50px;
+    padding-right: 50px;
+  }
+}
+
+@media (max-width: 768px) {
+  .market-status-heading-unique {
+    font-size: 1.8rem;
+  }
+
+  .market-card-unique {
+    padding: 15px;
+    width: 100%;
+  }
+
+  .market-status-tag-unique {
+    font-size: 0.8rem;
+    padding: 4px 10px;
+  }
+
+  .market-card-title-unique {
+    font-size: 1rem;
+  }
+
+  .market-card-info-unique {
+    font-size: 0.9rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .market-status-heading-unique {
+    font-size: 1.5rem;
+  }
+
+  .market-card-unique {
+    padding: 10px;
+  }
+
+  .market-status-tag-unique {
+    font-size: 0.7rem;
+    padding: 3px 8px;
+  }
+
+  .market-card-title-unique {
+    font-size: 0.9rem;
+  }
+
+  .market-card-info-unique {
+    font-size: 0.8rem;
+  }
+}

--- a/assets/js/market-time.js
+++ b/assets/js/market-time.js
@@ -1,0 +1,60 @@
+async function fetchMarketDataUnique() {
+  try {
+    const response = await fetch(
+      "https://www.alphavantage.co/query?function=MARKET_STATUS&apikey=IVLR8O4HGBJ1B41T"
+    );
+    const data = await response.json();
+    const markets = data.markets;
+    const container = document.getElementById("marketStatusContainerUnique");
+
+    // Clear the container for new data
+    container.innerHTML = "";
+
+    // Loop through the market data and create cards
+    markets.forEach((market) => {
+      const card = document.createElement("div");
+      card.classList.add("market-card-unique");
+
+      const status = document.createElement("span");
+      status.classList.add("market-status-tag-unique");
+      status.textContent = market.current_status === "open" ? "Open" : "Closed";
+      status.classList.add(
+        market.current_status === "open"
+          ? "market-status-open-unique"
+          : "market-status-closed-unique"
+      );
+
+      const title = document.createElement("h3");
+      title.classList.add("market-card-title-unique");
+      title.textContent = `${market.region} (${market.market_type})`;
+
+      const exchanges = document.createElement("p");
+      exchanges.classList.add("market-card-info-unique");
+      exchanges.textContent = `Primary Exchanges: ${market.primary_exchanges}`;
+
+      const time = document.createElement("p");
+      time.classList.add("market-card-info-unique");
+      time.textContent = `Open: ${market.local_open}, Close: ${market.local_close}`;
+
+      const notes = document.createElement("p");
+      notes.textContent = market.notes ? `Notes: ${market.notes}` : "";
+      notes.classList.add("market-card-notes-unique");
+
+      card.appendChild(status);
+      card.appendChild(title);
+      card.appendChild(exchanges);
+      card.appendChild(time);
+      card.appendChild(notes);
+
+      container.appendChild(card);
+    });
+  } catch (error) {
+    console.error("Error fetching market data:", error);
+  }
+}
+
+// Call the function once to load data initially
+fetchMarketDataUnique();
+
+// Set up an interval to refresh the data every 1 minute (60000 ms)
+setInterval(fetchMarketDataUnique, 60000); // 60 seconds interval

--- a/trends.html
+++ b/trends.html
@@ -24,6 +24,7 @@
     <link rel="stylesheet"  href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" />
     <link rel="stylesheet"  href="navbar.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
+    <link rel="stylesheet" href="./assets/css/market-time.css">
 <body>
 
   
@@ -151,6 +152,14 @@
         <i class="fas fa-home" style="font-size: 30px;"></i>
     </a>
 </div>
+
+<section class="market-status-section-unique">
+  <h2 class="market-status-heading-unique">Global Market Open & Close Status</h2>
+  <div class="market-scroll-container-unique">
+    <div class="market-card-container-unique" id="marketStatusContainerUnique"></div>
+  </div>
+</section>
+
   <div class="container"><br><br>
     <!-- TradingView Widget BEGIN -->
      <br><br>
@@ -420,6 +429,7 @@
   <script>document.getElementById("copyright-year").textContent = new Date().getFullYear();</script>
   <a href="#" class="back-to-top"><i class="lni-chevron-up"></i></a>
   <script src="./assets/js/trends.js"></script>
+  <script src="./assets/js/market-time.js"></script>
   <script src="./assets/js/subscribe.js"></script>
   <script src="./assets/js/vendor/jquery-1.12.4.min.js"></script>
   <script src="./assets/js/vendor/modernizr-3.7.1.min.js"></script>


### PR DESCRIPTION
## Related Issue
#1334 

## Description
integrated a real-time global market status feature on the trends.html page. This feature will display the open/close status of various markets (e.g., equities in the US, UK, Asia, etc.). The data will be presented in responsive, scrollable cards to ensure efficient use of page space. The section will auto-update every minute to keep the information current.

## Type of PR

- [ ] Bug fix
- [x] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

## Screenshots / videos (if applicable)
![Screenshot from 2024-10-18 10-02-00](https://github.com/user-attachments/assets/e4fe9cdc-cb9a-4974-9b5a-2fd6b1efbcef)


## Checklist:
- [x] I have performed a self-review of my code
- [x] I have read and followed the Contribution Guidelines.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [x] I have commented my code, particularly in hard-to-understand areas.
<!-- [X] - put a cross/X inside [] to check the box -->


