### PR TITLE
scroll-up/down arrows on landing hiding bot button changed its css

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,35 +46,21 @@
     });
   };
   </script>
+
+
+
+
   <style>
-    .scroll-btn {
-    position: fixed; 
-    top: 150px; 
-    right: 50px; 
-    background-color: #635adc; 
-    color: white; 
-    border: none; 
-    border-radius: 50%; 
-    width: 45px; 
-    height: 45px; 
-    font-size: 24px; 
-    cursor: pointer; 
-    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.3);
-    transition: background-color 0.3s; 
-    display: flex;
-    z-index: 1000;
-    justify-content: center;
-    align-items: center;
-}
+
 .scrlUp{
   position: fixed;
   background-color: #635adc;
   box-shadow: 0 2px 5px rgba(0, 0, 0, 0.3);
-  top: 84.89%;
-  right: 40px;
+  top: 91.89%;
+  right: 4px;
   bottom: 900px;
-  width:50px; 
-  height: 50px; 
+  width:40px; 
+  height: 40px; 
   display: flex;
   z-index: 1000;
   justify-content: center;
@@ -82,7 +68,8 @@
   border-radius: 50%;
   cursor: pointer;
   font-size: 30px;
-  transition: background-color 0.3s; 
+  transition: background-color 0.3s;
+  color: white;
 }
 
 .scrlUp:hover{
@@ -414,19 +401,19 @@ if (body.classList.contains('dark-mode')) {
   </script>
   <style>
     .scroll-btn {
-    position: fixed; 
-    top: 150px; 
-    right: 50px; 
-    background-color: #635adc; 
-    color: white; 
-    border: none; 
-    border-radius: 50%; 
-    width: 45px; 
-    height: 45px; 
-    font-size: 24px; 
-    cursor: pointer; 
+   position: fixed;
+    top: 115px;
+    right: 4px;
+    background-color: #635adc;
+    color: white;
+    border: none;
+    border-radius: 50%;
+    width: 40px;
+    height: 40px;
+    font-size: 24px;
+    cursor: pointer;
     box-shadow: 0 2px 5px rgba(0, 0, 0, 0.3);
-    transition: background-color 0.3s; 
+    transition: background-color 0.3s;
     display: flex;
     z-index: 1000;
     justify-content: center;


### PR DESCRIPTION
## Related Issue

- Javascript function handelnextButton not working to swipe to next in slack-list.
- slack-list arrows go black in dark mode. 

## Description

- make changes in css of scroll up and down arrows of landing page so that user can access bot clearly. 


## Type of PR

- [x] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

## Screenshots / videos (if applicable)

- **Before changes**

![Screenshot 2024-10-19 220823](https://github.com/user-attachments/assets/4ba122bf-39b9-4428-8461-dd9c738b0d36)

- **After chnages**

![Screenshot 2024-10-19 220731](https://github.com/user-attachments/assets/16069945-d251-4baa-a177-e3d95329ceb4)


## Checklist:
- [x] I have performed a self-review of my code
- [x] I have read and followed the Contribution Guidelines.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [x] I have commented my code, particularly in hard-to-understand areas.
<!-- [X] - put a cross/X inside [] to check the box -->

## Additional context:

I just adjusted the css of arrows so that user can access ArthaSaathi.
