### PR TITLE
Fixed the scroll up button overlapping on home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
 
 
 
-
+<style>
 
 .scrlUp{
   position: fixed;
@@ -51,7 +51,7 @@
   box-shadow: 0 2px 5px rgba(0, 0, 0, 0.3);
   top: 91.89%;
   right: 4px;
-  bottom: 900px;
+  bottom: 800px;
   width:40px; 
   height: 40px; 
   display: flex;
@@ -73,7 +73,7 @@
 }
 
 
-  </style>
+</style>
   
 <body>
   <div id="progressBar"></div>


### PR DESCRIPTION
## Related Issue
Closes: #1609 

## Description
The scroll up button was overlapping with the chat suport button onthe homepage.

## Type of PR

- [x] Bug fix
- [x] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

## Screenshots / videos (if applicable)

https://github.com/user-attachments/assets/0f4c43f4-b2a2-45f6-a1e1-274542be0850



## Checklist:
- [x] I have performed a self-review of my code
- [x] I have read and followed the Contribution Guidelines.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [ ] I have commented my code, particularly in hard-to-understand areas.
<!-- [X] - put a cross/X inside [] to check the box -->

## Additional context:
[Include any additional information or context that might be helpful for reviewers.]
