### PR TITLE
[Bug Fix] Resolve Double Scrollbars Issue in FAQ Section

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -182,7 +182,7 @@
       border-top: 1px solid #ddd;
     }
 
-    #progressBar {
+    <!-- #progressBar {
     position: fixed;
     top: 0;
     right: 0;
@@ -192,7 +192,7 @@
     z-index: 9999;
     transition: height 0.25s ease-in-out;
     border-radius: 10px ;
-}
+    } -->
 
 
 
@@ -386,12 +386,6 @@ background-color: #ddd; /* Button hover color in dark mode */
 
 
 
-  <!-- Progress Bar -->
-  <div class="progress-bar-container">
-    <div id="progressBar"></div>
-  </div>
-
-  <div id="progressBar"></div>
   <div class="preloader">
    <div class="loader">
      <div class="ytp-spinner">


### PR DESCRIPTION
### Related Issue
Fixes #1541

### Description
This pull request addresses the issue of double scrollbars appearing in the FAQ section when accessed through the "Help" link in the navbar. The changes ensure that only a single scrollbar is displayed, providing a smoother and more consistent user interface. Adjustments were made to the CSS to prevent multiple scrollbars from appearing and to maintain the intended layout.

### Type of PR
- [x] Bug fix - #1541

### Screenshots / Videos (if applicable)
![image](https://github.com/user-attachments/assets/e8b84cb1-842c-4a21-98ea-bf244dd8ebe5)


### Checklist
- [x] I have performed a self-review of my code.
- [x] I have read and followed the Contribution Guidelines.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [x] I have commented my code, particularly in hard-to-understand areas.

### Additional Context
The issue was reproducible in multiple browsers (Chrome, Firefox, Safari) on Windows 11. Fixing this will enhance the user experience by ensuring a clean and uncluttered interface in the FAQ section.