### PR TITLE
[Bug Fix] Correct Positioning of "Go Down" Button on Home Page

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -43,6 +43,21 @@
   }
 
 
+  .scroll-btn{
+    position: fixed;
+    right: 120px;
+    top: 475px;
+    z-index: 9999;
+    color: white;
+    border: none;
+    border-radius: 50%;
+    width: 50px;
+    height: 50px;
+    font-size: 20px;
+    cursor: pointer;
+    transition: background-color 0.3s;
+  }
+
   .circle {
     position: absolute;
     width: 25px;

--- a/index.html
+++ b/index.html
@@ -77,9 +77,6 @@
   
 <body>
   <div id="progressBar"></div>
-  <button id="scrollBtn" class="scroll-btn" onclick="scrollToNextSection()">
-    ↓
-  </button>
   <script>
     window.onscroll = function () {
       var winScroll = document.body.scrollTop || document.documentElement.scrollTop;


### PR DESCRIPTION
### Related Issue
Fixes #1543

### Description
This pull request resolves the incorrect positioning of the "Go Down" button on the home page. The button is currently appearing vertically in the middle of the screen, disrupting the layout. The changes made ensure that the "Go Down" button is now placed to the left of the "ChatBot" button, creating a balanced and visually appealing layout that improves user navigation.

### Type of PR
- [x] Bug fix : #1543 

### Screenshots / Videos (if applicable)
![image](https://github.com/user-attachments/assets/a1f15643-0cdf-485c-bc51-42de618db85b)

### Checklist
- [x] I have performed a self-review of my code.
- [x] I have read and followed the Contribution Guidelines.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [x] I have commented my code, particularly in hard-to-understand areas.

### Additional Context
This fix addresses a layout issue that affected multiple browsers (Chrome, Firefox, Microsoft Edge) on Windows 11. By correctly positioning the "Go Down" button, the home page layout will now be more intuitive, enhancing the overall user experience.