### PR TITLE
Fixed the allignment of list (Quiz Links & Resources) in footer of QUIZ PAGE

### DIFF
--- a/quiz.html
+++ b/quiz.html
@@ -925,6 +925,26 @@ h2#question {
   }
 }
 
+/* Fixing Privacy Policy, Refund Policy and Licensing */
+ul.link li:nth-child(3) {
+  text-align: left; /* Aligning the text to the left */
+  margin-left: 0; 
+}
+ul.link li:nth-child(1), 
+ul.link li:nth-child(2) {
+  text-align: left; /* Aligning to the left */
+  margin-left: 0; 
+  padding: 5px 0; 
+}
+
+/* Fixing Tools (4th item), Blog (5th item), and Quiz (6th item) */
+ul.link li:nth-child(4), 
+ul.link li:nth-child(5), 
+ul.link li:nth-child(6) { 
+  text-align: left; 
+  margin-left: 0; 
+  padding: 5px 0; 
+}
 
 
   </style>


### PR DESCRIPTION
#1618 

## Related Issue
The allignment of list in the footer section of Quiz page was messed.

## Description
I have added the required CSS in (quiz.html) so that the list looks properly alligned.

## Type of PR
- [X] Bug fix

## Screenshots / videos (if applicable)
BEFORE:
![Screenshot (385)](https://github.com/user-attachments/assets/e34fddb2-ad09-459d-8d3b-43a70249d8f7)
AFTER:
![Screenshot (384)](https://github.com/user-attachments/assets/3bbb1c73-5309-455e-b79b-f91907c3711c)


## Checklist:
- [X] I have performed a self-review of my code
- [X] I have read and followed the Contribution Guidelines.
- [X] I have tested the changes thoroughly before submitting this pull request.
- [X] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [X] I have commented my code, particularly in hard-to-understand areas.
<!-- [X] - put a cross/X inside [] to check the box -->
