### PR TITLE
solve overlapping service icon

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1361,7 +1361,7 @@ p {
 }
 
 .single-services:hover .services-icon {
-  top: -30px;
+  top: -16px;
   scale: 0.75;
   box-shadow: 0 15px 45px rgba(0, 0, 0, 0.15);
   z-index: 10;


### PR DESCRIPTION
## Related Issue
 `issue: #1572 `

## Description
 solving overlapping of service icon from service box.

## Type of PR

- [x] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

## Screenshots / videos (if applicable)
Before:

![solve-after](https://github.com/user-attachments/assets/9758b856-10ba-4e54-8105-692ee3a49442)

After:

![solve](https://github.com/user-attachments/assets/b9d95670-9fd5-47ad-95ed-7330f6999f12)


## Checklist:
- [x] I have performed a self-review of my code
- [x] I have read and followed the Contribution Guidelines.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [x] I have commented my code, particularly in hard-to-understand areas.
<!-- [X] - put a cross/X inside [] to check the box -->

## Additional context:
 
