### PR TITLE
Fix Overlap Between Scroll Button and Chat Close Button

### DIFF
--- a/index.html
+++ b/index.html
@@ -731,7 +731,7 @@ registerCloseButton.addEventListener("click", function() {
   <style>
     .scroll-btn {
    position: fixed;
-    top: 115px;
+    top: 100px;
     right: 4px;
     background-color: #635adc;
     color: white;


### PR DESCRIPTION
## Related Issue
 `issue: #1548`

## Description
 Solve overlapping scroll down button to Chat close button

## Type of PR

- [x] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

## Screenshots / videos (if applicable)
 Before:

![before-overlap-X](https://github.com/user-attachments/assets/cb8bd044-9727-403b-8675-1d4b7e8a84e0)

After:

![after-X](https://github.com/user-attachments/assets/3506a32b-ac80-4c9c-8b5f-248ac1222fad)



## Checklist:
- [x] I have performed a self-review of my code
- [x] I have read and followed the Contribution Guidelines.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [x] I have commented my code, particularly in hard-to-understand areas.
<!-- [X] - put a cross/X inside [] to check the box -->

## Additional context:
 
