### PR TITLE
Expand the width of calculators for better visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -404,10 +404,11 @@ loginCloseButton.addEventListener("click", function() {
   var modal = document.getElementById("myModal");
   modal.style.display = "none";
 });
-=======
+</script>
+
           body.dark-mode {
     background-color: #fefefe;
-    color: #f1f1f1; /* Change text color to light for dark mode */
+    color: #f1f1f1; 
 }
 
 .dark-mode .para {

--- a/tools/sip.html
+++ b/tools/sip.html
@@ -835,6 +835,7 @@ registerCloseButton.addEventListener("click", function() {
           border-radius: 5px;
           box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
           margin: 20px 0;
+          width: 97%;
       }
       .form-control {
           width: 100%;
@@ -1035,7 +1036,9 @@ registerCloseButton.addEventListener("click", function() {
       <div><b>Terminal Bonus (%)</b></div>
       <div><input class="form-control" id="TerminalBonus" type="number" /></div>
       <br />
-      <div class="select" style="display: flex; flex-direction: row;"">
+      
+
+      <div class="select" style="display: flex; flex-direction: row; width: 100%;">
       <div class="centered-content">
         <input name="surrenderType" id="surrendered" type="radio" />
         <label for="surrendered"><b>Early Surrendered</b></label>

--- a/tools/sipcalculatorCss.css
+++ b/tools/sipcalculatorCss.css
@@ -10,6 +10,7 @@
   transform: scale(0.75);
   background: linear-gradient(35deg,#d1b3e5,#ffe3f0);
   transition: all 0.4s ease;
+  width: 30vw;
 }
 
 .page-container:hover{


### PR DESCRIPTION
## Related Issue
[Bug ] Expand the size of calculators on tools page. #1579

Issue: [Bug Title here] Expand the size of calculators on tools page. #1579
Issue no: #1579 

## Description
The size of calculators on tools page is very small as the options inside it are colliding each other.

I've solved the issue by expanding the width of calculators.

## Type of PR

- [ ] Bug fix
- [ ] Feature enhancement

## Screenshots / videos (if applicable)

Before: (Options are colliding each other.

![Screenshot 2024-10-20 184440](https://github.com/user-attachments/assets/21caab55-8bc8-4ca9-ba6e-a5589ea22ee3)

After:

![Screenshot 2024-10-20 184530](https://github.com/user-attachments/assets/7db6c83f-1361-4b98-9171-eac98d19ae24)

Before: (Text not visible inside the input box)

![Screenshot 2024-10-20 184634](https://github.com/user-attachments/assets/e28d3755-f727-4854-9a74-c2716e014c62)


After:

![Screenshot 2024-10-20 184715](https://github.com/user-attachments/assets/371c053d-9f42-4ee2-bd63-09ec8585c651)


## Checklist:
- [ x] I have performed a self-review of my code
- [ x] I have read and followed the Contribution Guidelines.
- [ x] I have tested the changes thoroughly before submitting this pull request.
- [ x] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [ x] I have commented my code, particularly in hard-to-understand areas.


## Additional context:
