### PR TITLE
Fixed Multiple Rendering of FAQ Section on Help Page

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -998,49 +998,6 @@
        </style>
 </head>
 <body>
-    <h1 style="color: #007BFF;">Frequently Asked Questions</h1>
-    <div class="faq-container">
-        <div class="faq-item">
-            <h3>What is FinVeda?</h3>
-            <div class="faq-answer">
-                <p>FinVeda is a platform that provides financial insights and innovative solutions.</p>
-            </div>
-        </div>
-        <div class="faq-item">
-            <h3>How can I contact support?</h3>
-            <div class="faq-answer">
-                <p>You can contact support via the Contact Us page or email us at support@finveda.com.</p>
-            </div>
-        </div>
-        <div class="faq-item">
-            <h3>What services do you offer?</h3>
-            <div class="faq-answer">
-                <p>We offer a range of services, including financial planning, investment advice, and more.</p>
-            </div>
-        </div>
-    </div>
-
-    <!-- Footer Section -->
-    
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
     <footer id="footer" class="footer-area pt-120">
       <div class="container">


### PR DESCRIPTION
### Related Issue
Fixes #1610

### Description
This pull request addresses the issue of the FAQ section rendering multiple times on the Help page. The issue caused inconsistent behavior in the user interface, where additional duplicate FAQ sections appeared after the first one. The fix ensures that the FAQ section is displayed only once, thereby maintaining a consistent and clean UI.

### Type of PR
- [x] Bug fix - #1610 

### Screenshots / Videos (if applicable)

https://github.com/user-attachments/assets/f54e6440-715d-4f64-9774-786af5ff9432



### Checklist
- [x] I have performed a self-review of my code.
- [x] I have read and followed the Contribution Guidelines.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [x] I have commented my code, particularly in hard-to-understand areas.

### Additional Context
The fix has been tested across different browsers (Chrome, Firefox, Brave) on Windows 11 to ensure consistency and improved user experience on the Help page. The changes now prevent multiple instances of the FAQ section from rendering, aligning the page with the expected behavior.


@sampadatiwari30 @ayush-that , please assign me labels for gssoc-ext level2 and hactoberfest-accepted, once the PR is merged.