### PR TITLE
Fixed active link highlighting issue on Tool button when on Home Page

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 
 <head>
   <meta charset="utf-8" />
-  <title>Tools - FinVeda</title>
+  <title>Home - FinVeda</title>
   <meta name="description" content="" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link rel="shortcut icon" href="../assets/images/favicon2.png" type="image/png" />


### PR DESCRIPTION
## Related Issue
#1677 solved

## Description
The issue where the Tool button was being incorrectly highlighted as the active link while the user was on the Home Page has been resolved. Now, the active link will correctly reflect the current page, ensuring accurate navigation feedback and improving the user experience across the site. This fix ensures that only the appropriate navbar button is highlighted when navigating the site.

## Type of PR

- [ ] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

## Screenshots / videos (if applicable)
![image](https://github.com/user-attachments/assets/7cd08e2a-af77-444c-a6c1-7d7a5c763213)

## Checklist:
- [ ] I have performed a self-review of my code
- [ ] I have read and followed the Contribution Guidelines.
- [ ] I have tested the changes thoroughly before submitting this pull request.
- [ ] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [ ] I have commented my code, particularly in hard-to-understand areas.
<!-- [X] - put a cross/X inside [] to check the box -->
