### PR TITLE
fixed logo on tools page

### DIFF
--- a/tools/sip.html
+++ b/tools/sip.html
@@ -281,7 +281,7 @@ box-shadow: 0 0 25px #03133c;
           </button> -->
           <div class="collapse navbar-collapse sub-menu-bar" id="navbarSupportedContent" style="margin: auto;">
             <div class="icon1">
-              <img src="../assets/images/icon.png" alt="icon.png">
+              <img src="/assets/images/icon.webp" alt="icon.webp">
             </div> 
             <ul id="nav" class="navbar-nav ml-auto" style="margin: auto;">
               <li class="nav-item">


### PR DESCRIPTION
## Related Issue
[Cite any related issue(s) this pull request addresses. If none, simply state “None”]

## Description
fixed the logo which was not visible earlier on the tools page

fixes #1708 
close #1708 

**before
![2024-10-21](https://github.com/user-attachments/assets/52e4ff45-59fa-44cb-8230-dffe23b99cef)
**

**after**

![2024-10-21 (6)](https://github.com/user-attachments/assets/63563d6d-1ae7-4c83-9098-1aec61735ec0)


## Type of PR

- [#1708  ] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

## Screenshots / videos (if applicable)
[Attach any relevant screenshots or videos demonstrating the changes]

## Checklist:
- [x ] I have performed a self-review of my code
- [x ] I have read and followed the Contribution Guidelines.
- [ x] I have tested the changes thoroughly before submitting this pull request.
- [x ] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [ ] I have commented my code, particularly in hard-to-understand areas.
<!-- [X] - put a cross/X inside [] to check the box -->

## Additional context:
please add hacktober fest and level 2 label
