### PR TITLE
Fixed the entire CSS of the lists in footer section of Contact page.

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -1169,6 +1169,56 @@ registerCloseButton.addEventListener("click", function() {
       max-width: 100%;
     }}
 
+    /* Fixing the foooter lists */
+    ul.link {
+        padding-left: 0; 
+        margin-left: 0; 
+    }
+
+    ul.link li {
+        margin-left: -15px; 
+    }
+    ul.link li:nth-child(3) {
+        position: relative;
+        left: -15px; 
+    }
+    ul.link li:nth-child(4), 
+    ul.link li:nth-child(5)   {
+        position: relative;
+        left: 15px; 
+    }
+
+
+    .link-wrapper .link {
+        padding-left: 0; 
+        margin-left: 0;  
+    }
+
+    .link-wrapper .link li {
+        margin-left: 0; 
+        padding-left: 15px; 
+    }
+
+    .resources-link li:nth-child(4), 
+    .resources-link li:nth-child(5), 
+    .resources-link li:nth-child(6)   {
+        position: relative;
+        left: -15px; 
+    }
+
+    .resources-link li:nth-child(1), 
+    .resources-link li:nth-child(4), 
+    .resources-link li:nth-child(5)  {
+        position: relative;
+        left: -15px !important; 
+    }
+    .resources-link li:nth-child(2) {
+        position: relative;
+        left: -10px; 
+    }
+
+
+
   </style>
 </body>
 
@@ -1282,7 +1332,7 @@ registerCloseButton.addEventListener("click", function() {
                     <div class="footer-title">
                         <h4 class="title custom-margin">Resources</h4>
                     </div>
-                    <ul class="link custom-margin">
+                    <ul class="link resources-link custom-margin">
                         <li><a href="./index.html"><i class="fas fa-home"></i> Home</a></li>
                         <li><a href="./about.html"><i class="fas fa-info-circle"></i> About Us</a></li>
                         <li><a href="./trends.html"><i class="fas fa-chart-line"></i> Trends</a></li>


### PR DESCRIPTION
Issue #1713 

## Related Issue
The lists were not alligned properly in the footer section of Contacts page.

## Description
I fixed the CSS of both the lists, and added an extra class (resources-link) in ul tag of Resources.

## Type of PR
- [X] Bug fix

## Screenshots / videos (if applicable)
BEFORE:
![Screenshot (402)](https://github.com/user-attachments/assets/9fdadabe-3ca5-42c1-9845-61ebdc1299d5)

AFTER:
![Screenshot (401)](https://github.com/user-attachments/assets/78a5f002-81d0-4c78-92ae-1a0de4af77e7)


## Checklist:
- [X] I have performed a self-review of my code
- [X] I have read and followed the Contribution Guidelines.
- [X] I have tested the changes thoroughly before submitting this pull request.
- [X] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [X] I have commented my code, particularly in hard-to-understand areas.
