### PR TITLE
link logo with home page and tool page logo correction

### DIFF
--- a/tools/sip.html
+++ b/tools/sip.html
@@ -281,9 +281,11 @@ box-shadow: 0 0 25px #03133c;
             <span class="toggler-icon"></span>
           </button> -->
           <div class="collapse navbar-collapse sub-menu-bar" id="navbarSupportedContent" style="margin: auto;">
+            <a href="../index.html">
             <div class="icon1">
               <img src="/assets/images/icon.webp" alt="icon.webp">
             </div> 
+            </a>
             <ul id="nav" class="navbar-nav ml-auto" style="margin: auto;">
               <li class="nav-item">
                 <a class="page-scroll" href="../index.html" style="color: rgb(237, 242, 244);">Home 🏡</a>


### PR DESCRIPTION
## Description
Tool page logo was missing and also linked with it home page.
Resolve issue- #1641 

## Type of PR

- [✓] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

## Screenshots / videos (if applicable)

https://github.com/user-attachments/assets/2d6ccab2-31dc-4da6-ab5b-1e12322940a4



## Checklist:
- [✓] I have performed a self-review of my code
- [✓] I have read and followed the Contribution Guidelines.
- [✓] I have tested the changes thoroughly before submitting this pull request.
- [✓] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [ ] I have commented my code, particularly in hard-to-understand areas.
<!-- [X] - put a cross/X inside [] to check the box -->


