### PR TITLE
the overlapping of icon is resolved #1827

### DIFF
--- a/navbar.css
+++ b/navbar.css
@@ -587,7 +587,7 @@ main
     top: 30%;
     display: flex;
     flex-direction: column;
-    gap: 25px;
+    gap: 12px;
   }
   
   .icon-content {


### PR DESCRIPTION
this PR resolves issue number #1827 
previously the facebook and bot icon were overlapping so i have asdjusted the gap between the icons

## Related Issue
none

## Description

this was previously

<img width="953" alt="Screenshot 2024-10-22 223103" src="https://github.com/user-attachments/assets/d976edf1-b211-494f-8dbe-ada5bdb8fc33">

after making the changes

<img width="950" alt="hvh" src="https://github.com/user-attachments/assets/6f622dcb-2dab-46ca-b1d1-70ad40227ffc">

the changes is visible in right hand side down corner

## Checklist:
- [ ] I have performed a self-review of my code
- [ ] I have read and followed the Contribution Guidelines.
- [ ] I have tested the changes thoroughly before submitting this pull request.
- [ ] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [ ] I have commented my code, particularly in hard-to-understand areas.
<!-- [X] - put a cross/X inside [] to check the box -->


