### PR TITLE
Add Automatic Contributors Scroller & Fix Hacktober Fest Image

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ FinVeda is a dynamic financial literacy app that'll help you Learn finance with 
 ### This project is now OFFICIALLY accepted for
 
 <div align="center">
-  <img src="https://cdn.discordapp.com/attachments/657543125190967316/1294560786114674748/Screenshot_2024-10-12_122347.png?ex=670b752f&is=670a23af&hm=26ddd7f41740b8b19ee4985e7568b3892091384b3b85e7165770a4b10f4d1050&" alt="Hacktoberfest 2024" width="80%">
+  <img src="https://github.com/neeru24/Connect_icons/blob/main/hacktober.png" alt="Hacktoberfest 2024" width="80%">
 </div>
 <br>
 
@@ -104,6 +104,10 @@ FinVeda is a dynamic financial literacy app that'll help you Learn finance with 
 ![-----------------------------------------------------](https://raw.githubusercontent.com/andreasbm/readme/master/assets/lines/rainbow.png)
 
 ### 💗 Contributors
+
+<p align ="center">
+    <img src="https://api.vaunt.dev/v1/github/entities/ayush-that/repositories/FinVeda/contributors?format=svg&limit=54" width="700" height= "250" />
+</p>
 
 <a href="https://github.com/ayush-that/FinVeda/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=ayush-that/FinVeda" />


### PR DESCRIPTION
- **Fixed**: Resolved the issue with the Hacktober Fest image that was not displaying in the README.
- **Added**: Implemented a contributors scroller that updates automatically.

### Details

- The README now properly displays the Hacktober Fest image, enhancing visibility for the event.
- The contributors scroller has been added to showcase all contributors dynamically, ensuring it reflects the latest contributions without manual updates.

Thank you for considering this pull request! Kindly merge it and assign me labels.

fixes: #1990 

## Before: 
![Screenshot 2024-10-24 183429](https://github.com/user-attachments/assets/1d493a17-f278-41de-8592-aaaadff2c964)

## After
![image](https://github.com/user-attachments/assets/2af358e8-e295-48d6-83d1-743b991cacb0)

https://github.com/user-attachments/assets/437cc74c-14eb-4d3a-bad2-521420806bfa


