### PR TITLE
Extra space fix in footer of home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -2694,11 +2694,7 @@
     <script src="./smoothScroll.js"></script>
 
     <script src="./assets/js/preloader.js"></script>
- 
-    <br /><br />
- 
-     
- 
+
     <link rel="stylesheet" href="visi.css">
     <!-- ############### Footer ############### -->
     <div class="visitor-counter">


### PR DESCRIPTION
## Related Issue
 issue_number: #2011 

## Description
 Extra space fix in the bottom of home page footer

## Type of PR

- [x] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

## Screenshots / videos (if applicable)
 Before:

![WhatsApp Image 2024-10-24 at 23 28 31_d02297e7](https://github.com/user-attachments/assets/0623a750-5c7d-4f4e-a741-fe78129072a0)

After:

![WhatsApp Image 2024-10-24 at 23 37 13_9d573d17](https://github.com/user-attachments/assets/8ffc38aa-4168-483d-bec9-c645397b2f60)


## Checklist:
- [x] I have performed a self-review of my code
- [x] I have read and followed the Contribution Guidelines.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [x] I have commented my code, particularly in hard-to-understand areas.
<!-- [X] - put a cross/X inside [] to check the box -->

## Additional context:
[Include any additional information or context that might be helpful for reviewers.]
