### PR TITLE
Fixed FAQ progress text which  were not visible in Dark mode

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -132,6 +132,7 @@ body {
     transition: width 0.3s ease;
 }
 
+/* Default (light mode) styles */
 .faq-item {
     margin: 20px 0;
     padding: 10px;
@@ -142,17 +143,28 @@ body {
 }
 
 .faq-item:hover {
-    border-color: blue;
+    border-color: #0000ff;
 }
 
 .faq-item.read {
     background-color: #f0f8ff;
 }
 
-/* Accordion Section */
-.accordion {
-    width: 100%;
-    margin: 0 auto;
+/* Dark mode styles */
+@media (prefers-color-scheme: dark) {
+    .faq-item {
+        border-color: #0000ff; /* Darker border for dark mode */
+        background-color: #eee7e7; /* Darker background for dark mode */
+        color: #080808; /* Light text color for dark mode */
+    }
+
+    .faq-item:hover {
+        border-color: lightblue; /* Light blue on hover for dark mode */
+    }
+
+    .faq-item.read {
+        background-color: #444; /* Slightly lighter background for read items in dark mode */
+    }
 }
 
 .accordion-button {


### PR DESCRIPTION


https://github.com/user-attachments/assets/ae4775ad-a379-4bb5-8fa6-8febf96c6bc3

## Related Issue
None.
## Description
This update addresses a visibility issue in the FAQ section when using dark mode. Previously, the text within the FAQ items was difficult to read against the dark background. This fix adjusts the CSS styles to ensure that the text color contrasts appropriately with the dark mode background, enhancing readability and overall user experience. The adjustments made ensure that the FAQ items remain accessible and visually appealing in both light and dark modes.




## Type of PR

- [x] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

## Screenshots / videos (if applicable)
[Attach any relevant screenshots or videos demonstrating the changes]

## Checklist:
- [x] I have performed a self-review of my code
- [x] I have read and followed the Contribution Guidelines.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [x] I have commented my code, particularly in hard-to-understand areas.
<!-- [X] - put a cross/X inside [] to check the box -->

## Additional context:
[Include any additional information or context that might be helpful for reviewers.]
