### PR TITLE
Improve visibility of progress bar during FAQ selection

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -117,7 +117,7 @@ body {
 }
 
 .progress {
-    height: 30px;
+    height: 25px;
     background-color: #e0e0e0;
     margin-bottom: 20px;
 }
@@ -164,7 +164,7 @@ body {
     }
 
     .faq-item.read {
-        background-color: #444; /* Slightly lighter background for read items in dark mode */
+        background-color: #919191; /* Slightly lighter background for read items in dark mode */
     }
 }
 
@@ -780,21 +780,21 @@ body.dark-mode {
 <body>  
     <style>
         /* Progress bar styles */
-        .progress-container {
+        /* .progress-container {
             width: 100%;
             background-color: #f3f3f3;
             position: fixed;
             top: 0;
             left: 0;
             z-index: 1000;
-        }
-        
+        } */
+/*         
         .progress-bar {
             height: 5px;
             width: 0%;
             background-color: #4caf50;
             transition: width 0.3s;
-        }
+        } */
 
         /* Footer styles */
         .footer {


### PR DESCRIPTION
## Related Issue
#2061 solved

## Description

Enhanced the progress bar’s visibility on the FAQ page to improve user experience. Previously, the progress bar was difficult to see, especially when interacting with FAQ items. The updates adjust its styling and color scheme for better contrast and clarity, ensuring a smoother navigation experience across the FAQ section.

## Type of PR

- [ ] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

## Screenshots / videos (if applicable)

https://github.com/user-attachments/assets/41ec4d33-97df-4342-9ee8-787fadc313f7



## Checklist:
- [ ] I have performed a self-review of my code
- [ ] I have read and followed the Contribution Guidelines.
- [ ] I have tested the changes thoroughly before submitting this pull request.
- [ ] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [ ] I have commented my code, particularly in hard-to-understand areas.
<!-- [X] - put a cross/X inside [] to check the box -->
