### PR TITLE
Placeholder overlapping fix

### DIFF
--- a/tools/sip.html
+++ b/tools/sip.html
@@ -1169,7 +1169,7 @@ registerCloseButton.addEventListener("click", function() {
  footer
 
         .container {
-main
+ 
             max-width: 600px;
             margin: 0 auto;
             padding: 20px;
@@ -1186,7 +1186,7 @@ main
             color: #555;
         }
         input[type="number"] {
-            width: 100%;
+            
             padding: 10px;
             margin-bottom: 20px;
             border: 1px solid #ddd;
@@ -1372,6 +1372,7 @@ main
           placeholder="Enter your total income"
           class="actual-income"
           id="actual-income"
+          
         />
         <label for="actual-deductions" class="income-label"
           >Total Deductions(Charity,Under 80GG,80E,80TTA,life insurance premium,
@@ -1382,6 +1383,7 @@ main
           placeholder="Enter your total deductions"
           class="actual-deductions"
           id="actual-deductions"
+        
         />
         <label for="pan-number" class="income-label">Pan Card Number:</label>
         <input


### PR DESCRIPTION
## Related Issue
 issue_number: #2107 

## Description
 Placeholder overlapping fix in tools page Income tax calculator section

## Type of PR

- [x] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

## Screenshots / videos (if applicable)
 Before:

![WhatsApp Image 2024-10-26 at 19 19 40_852aa37e](https://github.com/user-attachments/assets/d71efdf3-64e8-4277-98ec-c3d3f0c9b184)


After:

![Screenshot (342)](https://github.com/user-attachments/assets/107dee60-be7f-4c7b-bc5d-1e7d809d7d4a)



## Checklist:
- [x] I have performed a self-review of my code
- [x] I have read and followed the Contribution Guidelines.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [x] I have commented my code, particularly in hard-to-understand areas.
<!-- [X] - put a cross/X inside [] to check the box -->

## Additional context:
[Include any additional information or context that might be helpful for reviewers.]
