### PR TITLE
Add Card Layout for Privacy Policy Sections

### DIFF
--- a/blogs/privacy-policy.html
+++ b/blogs/privacy-policy.html
@@ -589,99 +589,115 @@ body {
         <div id="particles-1" class="particles"></div>
       </div>
     </header>
-    <div class="blog-content">
+   <div class="blog-content">
       <article>
-        <br><br><br><br>
-        <div class="header">
-        <h1 style="text-align: center;">Privacy Policy</h1>
-        </div><br>
-        <div class="Lastupdate">
-          Last updated: <span id="last-updated-date"></span>
-        </div>
-        <br>
-        <p>This Privacy Policy describes Our policies and procedures on the collection, use and disclosure of Your information when You use the Service and tells You about Your privacy rights and how the law protects You.</p>
-        <br>
-        <p>We use Your Personal data to provide and improve the Service. By using the Service, You agree to the collection and use of information in accordance with this Privacy Policy.</p>
-        <br><ol style="list-style: decimal;">
-        <li><h4>Personal Data</h4></li>
-        <br>
-        <p>While using Our Service, We may ask You to provide Us with certain personally identifiable information that can be used to contact or identify You. Personally identifiable information may include, but is not limited to:</p>
-        <br>
-        <ul style="list-style: circle; font-size: x-large; color: black;">
-          <li>
-            <p>Email address</p>
-          </li>
-          <li>
-            <p>First name and last name</p>
-          </li>
-          <li>
-            <p>Phone number</p>
-          </li>
-          <li>
-            <p>Usage Data</p>
-          </li>
-        </ul>
-        <br>
-        <li><h4>Usage Data</h4>
-        <br>
-        <p>Usage Data is collected automatically when using the Service.</p>
-        <br>
-        <p>Usage Data may include information such as Your Device's Internet Protocol address (e.g. IP address), browser type, browser version, the pages of our Service that You visit, the time and date of Your visit, the time spent on those pages, unique device identifiers and other diagnostic data.</p>
-        <br>
-        <p>When You access the Service by or through a mobile device, We may collect certain information automatically, including, but not limited to, the type of mobile device You use, Your mobile device unique ID, the IP address of Your mobile device, Your mobile operating system, the type of mobile Internet browser You use, unique device identifiers and other diagnostic data.</p>
-        <br>
-        <p>We may also collect information that Your browser sends whenever You visit our Service or when You access the Service by or through a mobile device.</p>
-        <br></li>
-        <li><h4>Information from Third-Party Social Media Services</h4>
-        <br>
-        <p>The Company allows You to create an account and log in to use the Service through the following Third-party Social Media Services:</p>
-        <br>
-        <ul style="list-style: circle;">
-          <li>Google</li>
-          <li>Facebook</li>
-          <li>Instagram</li>
-          <li>Twitter</li>
-          <li>LinkedIn</li>
-        </ul>
-        <br>
-        <p>If You decide to register through or otherwise grant us access to a Third-Party Social Media Service, We may collect Personal data that is already associated with Your Third-Party Social Media Service's account, such as Your name, Your email address, Your activities or Your contact list associated with that account.</p>
-        <br>
-        <p>You may also have the option of sharing additional information with the Company through Your Third-Party Social Media Service's account. If You choose to provide such information and Personal Data, during registration or otherwise, You are giving the Company permission to use, share, and store it in a manner consistent with this Privacy Policy.</p>
-        <br></li>
-        <li><h4>Tracking Technologies and Cookies</h4>
-        <br>
-        <p>We use Cookies and similar tracking technologies to track the activity on Our Service and store certain information. Tracking technologies used are beacons, tags, and scripts to collect and track information and to improve and analyze Our Service. The technologies We use may include:</p>
-        <br>
-        <ol style="list-style: decimal;">
-          <li><strong>Cookies -</strong> A cookie is a small file placed on Your Device. You can instruct Your browser to refuse all Cookies or to indicate when a Cookie is being sent. However, if You do not accept Cookies, You may not be able to use some parts of our Service. Unless you have adjusted Your browser setting so that it will refuse Cookies, our Service may use Cookies.</li>
+          <br><br><br><br>
+          <div class="header">
+              <h1 style="text-align: center;">Privacy Policy</h1>
+          </div>
           <br>
-          <li><strong>Web Beacons -</strong> Certain sections of our Service and our emails may contain small electronic files known as web beacons (also referred to as clear gifs, pixel tags, and single-pixel gifs) that permit the Company, for example, to count users who have visited those pages or opened an email and for other related website statistics (for example, recording the popularity of a certain section and verifying system and server integrity).</li>
-        </ol>
-        <br></li>
-        <li><h4>Children's Privacy</h4>
-        <br>
-        <p>Our Service does not address anyone under the age of 13. We do not knowingly collect personally identifiable information from anyone under the age of 13. If You are a parent or guardian and You are aware that Your child has provided Us with Personal Data, please contact Us. If We become aware that We have collected Personal Data from anyone under the age of 13 without verification of parental consent, We take steps to remove that information from Our servers.</p>
-        <br>
-        <p>If We need to rely on consent as a legal basis for processing Your information and Your country requires consent from a parent, We may require Your parent's consent before We collect and use that information.</p>
-        <br></li>
-        <li><h4>Links to Other Websites</h4>
-        <br>
-        <p>Our Service may contain links to other websites that are not operated by Us. If You click on a third party link, You will be directed to that third party's site. We strongly advise You to review the Privacy Policy of every site You visit. We have no control over and assume no responsibility for the content, privacy policies or practices of any third party sites or services.</p>
-        <br></li>
-        <li><h4>Changes to this Privacy Policy</h4>
-        <br>
-        <p>We may update Our Privacy Policy from time to time. We will notify You of any changes by posting the new Privacy Policy on this page. You are advised to review this Privacy Policy periodically for any changes. Changes to this Privacy Policy are effective when they are posted on this page.</p>
-        </li>
-          </ol>
+          <div class="Lastupdate">
+              Last updated: <span id="last-updated-date"></span>
+          </div>
+          <br>
+          <p>This Privacy Policy describes Our policies and procedures on the collection, use and disclosure of Your information when You use the Service and tells You about Your privacy rights and how the law protects You.</p>
+          <br>
+          <p>We use Your Personal data to provide and improve the Service. By using the Service, You agree to the collection and use of information in accordance with this Privacy Policy.</p>
+          <br>
+  
+          <div class="card">
+              <h4>1. Personal Data</h4>
+              <p>While using Our Service, We may ask You to provide Us with certain personally identifiable information that can be used to contact or identify You. Personally identifiable information may include, but is not limited to:</p>
+              <ul style="list-style: circle; font-size: x-large; color: black;">
+                  <li>Email address</li>
+                  <li>First name and last name</li>
+                  <li>Phone number</li>
+                  <li>Usage Data</li>
+              </ul>
+          </div>
+          <br>
+  
+          <div class="card">
+              <h4>2. Usage Data</h4>
+              <p>Usage Data is collected automatically when using the Service.</p>
+              <p>Usage Data may include information such as Your Device's Internet Protocol address (e.g. IP address), browser type, browser version, the pages of our Service that You visit, the time and date of Your visit, the time spent on those pages, unique device identifiers and other diagnostic data.</p>
+              <p>When You access the Service by or through a mobile device, We may collect certain information automatically, including, but not limited to, the type of mobile device You use, Your mobile device unique ID, the IP address of Your mobile device, Your mobile operating system, the type of mobile Internet browser You use, unique device identifiers and other diagnostic data.</p>
+              <p>We may also collect information that Your browser sends whenever You visit our Service or when You access the Service by or through a mobile device.</p>
+          </div>
+          <br>
+  
+          <div class="card">
+              <h4>3. Information from Third-Party Social Media Services</h4>
+              <p>The Company allows You to create an account and log in to use the Service through the following Third-party Social Media Services:</p>
+              <ul style="list-style: circle;">
+                  <li>Google</li>
+                  <li>Facebook</li>
+                  <li>Instagram</li>
+                  <li>Twitter</li>
+                  <li>LinkedIn</li>
+              </ul>
+              <p>If You decide to register through or otherwise grant us access to a Third-Party Social Media Service, We may collect Personal data that is already associated with Your Third-Party Social Media Service's account, such as Your name, Your email address, Your activities or Your contact list associated with that account.</p>
+              <p>You may also have the option of sharing additional information with the Company through Your Third-Party Social Media Service's account. If You choose to provide such information and Personal Data, during registration or otherwise, You are giving the Company permission to use, share, and store it in a manner consistent with this Privacy Policy.</p>
+          </div>
+          <br>
+  
+          <div class="card">
+              <h4>4. Tracking Technologies and Cookies</h4>
+              <p>We use Cookies and similar tracking technologies to track the activity on Our Service and store certain information. Tracking technologies used are beacons, tags, and scripts to collect and track information and to improve and analyze Our Service. The technologies We use may include:</p>
+              <ol style="list-style: decimal;">
+                  <li><strong>Cookies -</strong> A cookie is a small file placed on Your Device. You can instruct Your browser to refuse all Cookies or to indicate when a Cookie is being sent. However, if You do not accept Cookies, You may not be able to use some parts of our Service. Unless you have adjusted Your browser setting so that it will refuse Cookies, our Service may use Cookies.</li>
+                  <br>
+                  <li><strong>Web Beacons -</strong> Certain sections of our Service and our emails may contain small electronic files known as web beacons (also referred to as clear gifs, pixel tags, and single-pixel gifs) that permit the Company, for example, to count users who have visited those pages or opened an email and for other related website statistics (for example, recording the popularity of a certain section and verifying system and server integrity).</li>
+              </ol>
+          </div>
+          <br>
+  
+          <div class="card">
+              <h4>5. Children's Privacy</h4>
+              <p>Our Service does not address anyone under the age of 13. We do not knowingly collect personally identifiable information from anyone under the age of 13. If You are a parent or guardian and You are aware that Your child has provided Us with Personal Data, please contact Us. If We become aware that We have collected Personal Data from anyone under the age of 13 without verification of parental consent, We take steps to remove that information from Our servers.</p>
+              <p>If We need to rely on consent as a legal basis for processing Your information and Your country requires consent from a parent, We may require Your parent's consent before We collect and use that information.</p>
+          </div>
+          <br>
+  
+          <div class="card">
+              <h4>6. Links to Other Websites</h4>
+              <p>Our Service may contain links to other websites that are not operated by Us. If You click on a third party link, You will be directed to that third party's site. We strongly advise You to review the Privacy Policy of every site You visit. We have no control over and assume no responsibility for the content, privacy policies or practices of any third party sites or services.</p>
+          </div>
+          <br>
+  
+          <div class="card">
+              <h4>7. Changes to this Privacy Policy</h4>
+              <p>We may update Our Privacy Policy from time to time. We will notify You of any changes by posting the new Privacy Policy on this page. You are advised to review this Privacy Policy periodically for any changes. Changes to this Privacy Policy are effective when they are posted on this page.</p>
+          </div>
       </article>
-    </div>
+  </div>
+  
+
+  
     <style>
       .blog-content {
       text-align: left;
       margin-left: auto;
       margin-right: auto;
+      padding: 20px;
       max-width: 80%; /* Adjust this value to increase or decrease the margins */
       }
+
+
+      .card {
+          border: 1px solid #ccc;
+          border-radius: 8px;
+          padding: 16px;
+          margin: 16px 0;
+          box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+          transition: transform 0.3s, box-shadow 0.3s;
+      }
+  
+      .card:hover {
+          transform: scale(1.02);
+          box-shadow: 0 4px 10px rgba(0, 0, 0, 0.2);
+      }
+
     </style>
 
   


### PR DESCRIPTION
This pull request introduces a card layout for the Privacy Policy sections to enhance readability and user experience. Each section is now wrapped in a card-like design, making it visually distinct and easier to navigate.
### Changes Made:

- Implemented card structure for all points in the Privacy Policy.
- Added CSS styles for card design and hover effects to improve interactivity.

### Impact: 

This update improves the overall aesthetic and organization of the Privacy Policy, providing a clearer structure for users.

Kindly merge it and assign me level 2 for this task.

fixes: #2006 

#### Before:

https://github.com/user-attachments/assets/5a7d7bf0-ba51-4a1f-b892-838066851171

#### After: 
![image](https://github.com/user-attachments/assets/d1ee7ae2-983e-43e5-8258-3bb2da6d226f)

https://github.com/user-attachments/assets/e0e14dca-2120-42bf-907e-6fea41c6db13

