### PR TITLE
Fix Redundant Contributors Scroller in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,10 +108,6 @@ FinVeda is a dynamic financial literacy app that'll help you Learn finance with 
     <img src="https://api.vaunt.dev/v1/github/entities/ayush-that/repositories/FinVeda/contributors?format=svg&limit=54" width="700" height="250" />
 </p>
 
-<p align="center">
-    <img src="https://api.vaunt.dev/v1/github/entities/ayush-that/repositories/FinVeda/contributors?format=svg&limit=54" width="700" height="250" />
-</p>
-
 <a href="https://github.com/ayush-that/FinVeda/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=ayush-that/FinVeda" />
 </a>


### PR DESCRIPTION
In reviewing the contributors scroller on the README, I discovered that the code responsible for displaying the contributors was implemented twice. This redundancy was causing the contributors to appear twice on the page, which led to confusion for users.

### Changes Made
- Removed the duplicated code for the contributors scroller to ensure that contributors are displayed only once.
- Verified that the scroller now appears correctly and enhances the overall user experience.

### Result
The contributors scroller now functions as intended, displaying each contributor only once, which improves the clarity and appearance of the page.

**Thank you for considering this fix!**
Kindly merge it and assign me the level 1.

fixes: #2146 

## Before:
![Screenshot 2024-10-26 224523](https://github.com/user-attachments/assets/f178688c-2878-43fe-a187-1f737858524f)


## After:
![image](https://github.com/user-attachments/assets/e43ae9b3-d53a-4e12-8211-65ce9aafc1eb)
