### PR TITLE
 Fix Active Link Displaying Correctly on Trend Page

### DIFF
--- a/trends.html
+++ b/trends.html
@@ -170,13 +170,13 @@ body.dark-mode {
             </div> 
             <ul id="nav" class="navbar-nav ml-auto" style="margin: auto;">
               <li class="nav-item">
-                <a class="page-scroll active-link" href="./index.html" style="color: rgb(237, 242, 244);">Home 🏡</a>
+                <a class="page-scroll" href="./index.html" style="color: rgb(237, 242, 244);">Home 🏡</a>
               </li>
               <li class="nav-item">
                 <a class="page-scroll" href="./about.html" style="color: rgb(237, 242, 244);">About Us 📖</a>
               </li>    
               <li class="nav-item">
-                <a class="page-scroll" href="./trends.html" style="color: rgb(237, 242, 244);">Trends 📈</a>
+                <a class="page-scroll active-link" href="./trends.html" style="color: rgb(237, 242, 244);">Trends 📈</a>
               </li>
               <li class="nav-item">
                 <a class="page-scroll" href="./tools/sip.html" style="color: rgb(237, 242, 244);">Tools 🔧</a>


### PR DESCRIPTION
## Related Issue
#2227 fixed
## Description
The trend page currently shows the active link indicator on the home button rather than the trend button, which disrupts navigational clarity for users. This update ensures that the active link correctly highlights the trend button when on the trend page, providing a consistent user experience and clear indication of the user’s current location within the website.

## Type of PR

- [ ] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

## Screenshots / videos (if applicable)
![image](https://github.com/user-attachments/assets/43329abc-1b8f-41f1-af2d-bde6870ff7d6)

## Checklist:
- [ ] I have performed a self-review of my code
- [ ] I have read and followed the Contribution Guidelines.
- [ ] I have tested the changes thoroughly before submitting this pull request.
- [ ] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [ ] I have commented my code, particularly in hard-to-understand areas.
<!-- [X] - put a cross/X inside [] to check the box -->

