### PR TITLE
Fixed the table contents that were not showing in light mode in career page

### DIFF
--- a/careers.html
+++ b/careers.html
@@ -772,7 +772,7 @@
     </section>
 
     <style>
-      /* Section Styling */
+/* Section Styling */
 section {
   font-family: Arial, sans-serif;
   padding: 20px;
@@ -877,6 +877,12 @@ section h2 {
   background-color: #bbdefb;
 }
 
+/* Dark Mode Specific Styling */
+.dark-mode .jobs-table th, 
+.dark-mode .jobs-table td {
+  color: #000; /* Set table font color to black in dark mode */
+}
+
 /* Responsive Styling */
 @media screen and (max-width: 600px) {
   .search-container input[type="text"] {
@@ -888,6 +894,7 @@ section h2 {
     font-size: 14px;
   }
 }
+
 
     </style>
 


### PR DESCRIPTION


# 🛠️ Fixes Issue
Fixes: #2481 

# 👨‍💻 Description

## What does this PR do?

**Description:**

We resolved an issue where table text became difficult to read when switching to dark mode due to font color automatically changing to white. By implementing a `.dark-mode` class in the HTML and adjusting the CSS, we ensured that text inside the table elements (`<th>` and `<td>`) remains black in dark mode, improving readability and maintaining visual consistency. This approach leverages a toggle function that applies the `.dark-mode` class to the `<body>` element, allowing dark mode styling without impacting overall usability. 

.

# 📄 Type of Change
Bug fix
# 📷 Screenshots/GIFs (if any)


https://github.com/user-attachments/assets/1b742886-70e3-4437-a4e0-2729ffd0ac96



# ✅ Checklist
- [x] I am a participant of GSSoC-ext.
- [x] I have followed the contribution guidelines of this project.
- [x] I have made this change from my own.
- [ ] I have taken help from some online resources.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have added documentation to explain my changes.

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.


# 🤝 GSSoC Participation
- [x] This PR is submitted under the GSSoC program.
- [x] I have taken prior approval for this feature/fix.