### PR TITLE
Update <h1> Text Color for Light and Dark Modes

### DIFF
--- a/contributors.html
+++ b/contributors.html
@@ -489,12 +489,12 @@
       </div>
     </header>
 
-    <div class="content min-h-screen text-black dark:text-gray-200">
-      <div class="container mx-auto py-8">
-        <h1 class="text-center text-3xl font-semibold mb-8">🤝 FinVeda - Contributors</h1>
-        <div id="contributors" class="contributors flex flex-wrap justify-center gap-8"></div>
-      </div>
-    </div>
+<div class="content min-h-screen text-black dark:text-gray-200">
+  <div class="container mx-auto py-8">
+    <h1 class="text-center text-3xl font-semibold mb-8 text-black dark:text-gray-200">🤝 FinVeda - Contributors</h1>
+    <div id="contributors" class="contributors flex flex-wrap justify-center gap-8"></div>
+  </div>
+</div>
     <!-- Timed popup that will appear after succesful submission of feebback form! -->
     <button class="notification" id="successnotification" style="display:none;">
       <span class="message" id="successmsg">Submitted successfully!</span>

--- a/contributors.html
+++ b/contributors.html
@@ -21,7 +21,13 @@
   <!-- Linked CSS for social logos -->
   <link rel="stylesheet" href="../assets/css/index.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" />
+  <style>
+    /* Specific rule for h1 in light mode */
+    body:not(.dark) h1 {
+       color: black !important; 
+     }
 
+  </style>
 <body>
   <div id="progressBar"></div>
   <div class="circle-container">

--- a/contributors.html
+++ b/contributors.html
@@ -491,7 +491,10 @@
 
 <div class="content min-h-screen text-black dark:text-gray-200">
   <div class="container mx-auto py-8">
-    <h1 class="text-center text-3xl font-semibold mb-8 text-black dark:text-gray-200">🤝 FinVeda - Contributors</h1>
+    <h1 class="text-center text-3xl font-semibold mb-8 text-black dark:text-gray-200">
+    🤝 FinVeda - Contributors
+   </h1>
+
     <div id="contributors" class="contributors flex flex-wrap justify-center gap-8"></div>
   </div>
 </div>


### PR DESCRIPTION
## Title: Update `<h1>` Text Color for Light and Dark Modes

### Description:
This pull request addresses the text color of the main `<h1>` heading in the FinVeda Contributors section of the webpage. The objective is to enhance readability and maintain a consistent user experience across different display modes (light and dark).

### Changes Made:
- **Updated `<h1>` Text Color in Light Mode:**
  - The text color for the `<h1>` heading has been set to `black` when light mode is enabled. This adjustment ensures that the heading is clear and easily readable against lighter backgrounds.
  
- **Retained Dark Mode Styling:**
  - The existing dark mode styling has been preserved by keeping the `dark:text-gray-200` class. This ensures that the text appears in a suitable gray shade when the dark mode is activated, maintaining visual coherence.

### fixes: #2454 

## Before: 
![Screenshot 2024-10-30 164554](https://github.com/user-attachments/assets/507e8cf8-4397-4014-b8a5-ee1d34cec3c1)

## After: 
![image](https://github.com/user-attachments/assets/cbeff8d1-84ac-4afb-9810-4dded2cc6366)