### PR TITLE
Add Project Statistics in Contributors page done ! 

### DIFF
--- a/contributors.html
+++ b/contributors.html
@@ -493,8 +493,97 @@
         </div>
         <div id="particles-1" class="particles"></div>
       </div>
+
+      <style>
+
+        /* Stats Section */
+.contributor-stats {
+
+  max-width: 1000px;
+  margin: 0 auto;
+  padding: 3rem 0;
+  text-align: center;
+  background-color: #ffffff;
+
+
+}
+
+.contributor-stats h2 {
+
+  font-size: 3rem;
+  margin-bottom: 2rem;
+
+}
+
+.contributor-stats-grid {
+
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 2rem;
+
+}
+
+.contributor-stat-card {
+
+  background-color: #ffffff;
+  border: 1px solid #c4cbd1;
+  border-radius: 10px;
+  padding: 1.5rem;
+  text-align: center;
+
+}
+
+.contributor-stat-card .contributor-icon {
+
+  font-size: 2rem;
+  margin-bottom: 1rem;
+
+}
+
+.contributor-stat-card h3 {
+
+  font-size: 2rem;
+  margin-bottom: 0.5rem;
+
+}
+
+.contributor-stat-card p {
+
+  color: #5a6881;
+  
+}
+
+      </style>
     </header>
 
+    <section class="contributor-stats">
+      <h2>Project Statistics</h2>
+      <div class="contributor-stats-grid" id="statsGrid">
+    <div class="contributor-stat-card">
+        <div class="contributor-icon"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"></path><circle cx="9" cy="7" r="4"></circle><path d="M23 21v-2a4 4 0 0 0-3-3.87"></path><path d="M16 3.13a4 4 0 0 1 0 7.75"></path></svg></div>
+        <h3>234</h3>
+        <p>Contributors</p>
+    </div>
+
+    <div class="contributor-stat-card">
+        <div class="contributor-icon"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"></circle><line x1="1.05" y1="12" x2="7" y2="12"></line><line x1="17.01" y1="12" x2="22.96" y2="12"></line></svg></div>
+        <h3>2330</h3>
+        <p>Total Contributions</p>
+    </div>
+
+    <div class="contributor-stat-card">
+        <div class="contributor-icon"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"></polygon></svg></div>
+        <h3>162</h3>
+        <p>GitHub Stars</p>
+    </div>
+
+    <div class="contributor-stat-card">
+        <div class="contributor-icon"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="6" y1="3" x2="6" y2="15"></line><circle cx="18" cy="6" r="3"></circle><circle cx="6" y="18" r="3"></circle><path d="M18 9a9 9 0 0 1-9 9"></path></svg></div>
+        <h3>409</h3>
+        <p>Forks</p>
+    </div>
+</div>
+  </section>
 <div class="content min-h-screen text-black dark:text-gray-200">
   <div class="container mx-auto py-8">
     <h1 class="text-center text-3xl font-semibold mb-8 text-black dark:text-gray-200">


### PR DESCRIPTION
Hello, PR
Add Project Statistics in Contributors page Done -

![Screenshot 2024-10-31 214958](https://github.com/user-attachments/assets/83e21d44-0f53-457f-9152-b75c10fdb1aa)


https://github.com/user-attachments/assets/81b638bf-699a-4f33-952e-5048db1a6821




# 📄 Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (adds or updates related documentation)

# ✅ Checklist
- [X] I am a participant of GSSoC-ext.
- [X] I have followed the contribution guidelines of this project.
- [X] I have made this change from my own.
- [X] I have taken help from some online resources.
- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have added documentation to explain my changes.

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.


# 🤝 GSSoC Participation
- [x] This PR is submitted under the GSSoC program.
- [x] I have taken prior approval for this feature/fix.