### PR TITLE
 Unintended Hero Section Display in Quiz Page

### DIFF
--- a/quiz.html
+++ b/quiz.html
@@ -287,86 +287,13 @@
         </div>
       </div>
     </div>
-    <div id="home" class="header-hero bg_cover" style="background-image: url(./assets/images/banner-bg.svg)">
-      <div class="container">
-        <h2 class="head-animate" style="font-size: 90px;">
-          WELCOME TO FINVEDA
-        </h2>
-        <div class="row justify-content-center">
-          <div class="col-lg-8">
-            <div class="header-hero-content text-center">
-              <style>
-                .head-animate {
-                  text-align: center;
-                  position: relative;
-                  top: 200px;
-                  color: transparent;
-                  -webkit-text-stroke: 2px white;
-                  -moz-text-stroke: 2px white;
-                  -ms-text-stroke: 2px white;
-                  font-weight: bold;
-                  background: url(./assets/images/back.png);
-                  -webkit-background-clip: text;
-                  -moz-background-clip: text;
-                  background-clip: text;
-                  background-position: 0 0;
-                  animation: back 20s linear infinite, hovering 1.5s ease-in-out infinite;
-                }
   
-                @keyframes back {
-                  100% {
-                    background-position: 2000px 0;
-                  }
-                }
-  
-                @keyframes hovering {
-                  0% {
-                    transform: translateY(0);
-                  }
-  
-                  50% {
-                    transform: translateY(-5px);
-                  }
-  
-                  100% {
-                    transform: translateY(0);
-                  }
-                }
-  
-                .header-hero-content h2 {
-                  font-size: 200px;
-                }
-              </style>
-              <br>
-              <br>
-              <p class="text wow fadeInUp" data-wow-duration="1.3s" data-wow-delay="0.8s"
-                style="visibility: visible; animation-duration: 1.3s; animation-delay: 0.8s;">
-                Wanna learn how to grow your money to become rich? We have
-                made becoming a stock market Guru easy with our AI
-                powered finance advisor - <b>Arth Sathi 🤵🏻</b>
-              </p>
-              <a href="#" class="main-btn wow fadeInUp" data-wow-duration="1.3s" data-wow-delay="1.1s"
-                onclick="window.botpressWebChat.sendEvent({ type: 'show' }); return false;"
-                style="visibility: visible; animation-duration: 1.3s; animation-delay: 1.1s;">
-                Chat with ArthaSathi 💬
-              </a>
-            </div>
-          </div>
-        </div>
-        <div class="row">
-          <div class="col-lg-12">
-            <div class="header-hero-image text-center wow fadeIn" data-wow-duration="1.3s" data-wow-delay="1.4s">
-              <img src="./assets/images/header-hero.webp" alt="hero" />
-            </div>
-          </div>
-        </div>
-      </div>
-      <div id="particles-1" class="particles"></div>
-    </div>
   </header>
-  <div class="blog-content wow fadeInUp\" style="display: flex; flex-direction: column;flex-wrap: wrap;" data-wow-duration="1.3s" data-wow-delay="0.5s">
+
+
+  <div class="blog-content wow fadeInUp\" style="margin-top: 100px;display: flex; flex-direction: column;flex-wrap: wrap;" data-wow-duration="1.3s" data-wow-delay="0.5s">
     <h2 class="test">Test your knowledge</h2>
-    <div style="position: absolute;width: 100px;height: 100px;right: 100px;z-index: 10; margin-top: 50px;" id="quiz-pic"><img src="./assets/images/quiz-anime2.webp" alt="QUIZ"></div>
+    <div style="position: absolute;width: 100px;height: 100px;right: 100px;z-index: 10; margin-top: 56px;" id="quiz-pic"><img src="./assets/images/quiz-anime2.webp" alt="QUIZ"></div>
     <div class="quiz-description wow fadeIn" data-wow-duration="1.3s" data-wow-delay="0.5s" style="width: 40%; margin: auto;">
       <div class="quiztitle wow fadeInUp" data-wow-duration="1.3s" data-wow-delay="0.5s">Welcome to the Quiz Challenge!</div>
       <div class="quizcontent wow fadeInUp" data-wow-duration="1.2s" data-wow-delay="0.6s">Get ready to test your knowledge and skill with our engaging quiz.</div>


### PR DESCRIPTION
# 🛠️ Fixes Issue
Fixes: #2511

# 👨‍💻 Description

## What does this PR do?

The Home Page Hero section is incorrectly rendering at the top of the Quiz page, which disrupts the intended flow and focus of the page. Only the quiz content should appear on this page to provide users with a straightforward quiz experience without unnecessary elements like the Hero section.

# 📄 Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (adds or updates related documentation)

# 📷 Screenshots/GIFs (if any)
BEFORE:-
![Screenshot 2024-11-01 095404](https://github.com/user-attachments/assets/edf577bf-0099-43c5-b706-6cd5307ef85c)

AFTER:-
![Screenshot 2024-11-01 095349](https://github.com/user-attachments/assets/7a23cce7-23c8-4643-bc2d-fb9f8243f12f)

# ✅ Checklist
- [x] I am a participant of GSSoC-ext.
- [x] I have followed the contribution guidelines of this project.
- [x] I have made this change from my own.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.

GSSOC EXT.

