### PR TITLE
Ensured consistent sizing of tco and income containers

### DIFF
--- a/tools/sip.html
+++ b/tools/sip.html
@@ -1945,16 +1945,18 @@
         :root {
           --font-family: 'Gill Sans', 'Gill Sans MT', Calibri, 'Trebuchet MS', sans-serif;
         }
-
         .tco-container,
         .main-income {
           background: linear-gradient(135deg, #0048ff 20%, #2cbc98 80%);
           padding: 20px;
+          height: 800px;
           border-radius: 10px;
           margin: 20px auto;
           text-align: center;
-          width: 90%;
+          width: 100%;
           max-width: 500px;
+          border: 1px solid black;
+          box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
         }
 
         .tco-header,


### PR DESCRIPTION
🛠️ Fixes Issue
Fixes: #2492 

👨‍💻 Description
What does this PR do?
This PR addresses an alignment issue on the "Tools" page where the containers for the Total Cost of Ownership (TCO) Calculator and the Income Tax Calculator differ in size. This inconsistency affects the visual layout and user experience.

Summary of Changes:
Adjusted the CSS styles of the TCO Calculator and Income Tax Calculator containers to ensure they have matching sizes.
Improved the overall aesthetic and usability of the "Tools" page.
Motivation and Context:
Maintaining a uniform layout enhances user experience and visual consistency across the page, making it more user-friendly.

Dependencies:
No additional dependencies are required for this change.
📄 Type of Change
 Bug fix (non-breaking change which fixes an issue)
 New feature (non-breaking change which adds functionality)
 Breaking change (fix or feature that would cause existing functionality to not work as expected)
 Documentation update (adds or updates related documentation)
📷 Screenshots/GIFs (if any)

✅ Checklist
 [✅](https://fsymbols.com/signs/tick/)I am a participant of GSSoC-ext.
 [✅](https://fsymbols.com/signs/tick/)I have followed the contribution guidelines of this project.
[✅](https://fsymbols.com/signs/tick/) I have made this change on my own.
 I have taken help from some online resources.
 [✅](https://fsymbols.com/signs/tick/)My code follows the style guidelines of this project.
 [✅](https://fsymbols.com/signs/tick/)I have performed a self-review of my own code.
 [✅](https://fsymbols.com/signs/tick/)I have added documentation to explain my changes.
Mandatory Tasks
 I have self-reviewed the code. A decent-sized PR without self-review might be rejected.
🤝 GSSoC Participation
 This PR is submitted under the GSSoC program.
 I have taken prior approval for this feature/fix.
📋 Bug Summary
On the "Tools" page, the containers for the Total Cost of Ownership (TCO) Calculator and Income Tax Calculator currently differ in size, affecting the visual alignment and consistency of the layout.

Steps to Reproduce
Navigate to the "Tools" page on the website.
Observe the containers for the TCO Calculator and the Income Tax Calculator.
Notice the difference in size between the two containers.
Expected Behavior
Both the TCO Calculator and Income Tax Calculator containers should have the same size, maintaining a consistent and balanced layout on the "Tools" page.
<img width="1185" alt="Screen Shot 2024-11-01 at 11 01 29 AM" src="https://github.com/user-attachments/assets/ea154ce2-0536-4f70-815a-703ee92c815b">
