### PR TITLE
Update Dark Mode Functionality, and Visibility of Next/Prev Buttons on About page✨

### DIFF
--- a/about.html
+++ b/about.html
@@ -19,6 +19,7 @@
   <link rel="stylesheet" href="./assets/css/popup.css" />
   <link rel="stylesheet" href="./assets/css/cookiepopup.css">
   <link rel="stylesheet" href="./assets/css/about.css" />
+  <!-- <link rel="stylesheet" href="./assets/css/about(inlines).css" /> -->
   <link rel="stylesheet" href="./assets/css/index.css" />
   <link rel="stylesheet" href="./assets/css/preloader.css" />
   <link rel="stylesheet" type="text/css" href="sipcalculatorCss.css">
@@ -510,10 +511,10 @@
 
   <style>
     .about-section {
-      background: linear-gradient(to bottom, #f8f9fa, #e9ecef);
+      /* background: linear-gradient(to bottom, #f8f9fa, #e9ecef); */
       padding: 6rem 1rem;
       font-family: system-ui, -apple-system, sans-serif;
-    }
+    } 
 
     .container {
       max-width: 1200px;
@@ -650,7 +651,7 @@
       width: 3rem;
       height: 3rem;
       border-radius: 50%;
-      background: white;
+      background: black;
       border: none;
       cursor: pointer;
       display: flex;
@@ -662,7 +663,7 @@
     }
 
     .carousel-control:hover {
-      background: #f8f9fa;
+      background: #000000;
       transform: translateY(-50%) scale(1.1);
     }
 
@@ -672,11 +673,11 @@
     }
 
     .carousel-control.prev {
-      left: 1rem;
+      left: 0rem;
     }
 
     .carousel-control.next {
-      right: 1rem;
+      right: 0rem;
     }
 
     .carousel-indicators {
@@ -775,12 +776,12 @@
         </div>
 
         <button class="carousel-control prev" id="prevBtn" aria-label="Previous slide">
-          <svg width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+          <svg width="30" height="30" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
             <path d="M15 19l-7-7 7-7"></path>
           </svg>
         </button>
         <button class="carousel-control next" id="nextBtn" aria-label="Next slide">
-          <svg width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+          <svg width="30" height="30" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
             <path d="M9 5l7 7-7 7"></path>
           </svg>
         </button>

--- a/assets/css/about.css
+++ b/assets/css/about.css
@@ -491,6 +491,8 @@ body.dark-mode {
     color: #fff;
   } 
   body.dark-mode .about-section {
+    padding: 6rem 1rem;
+    font-family: system-ui, -apple-system, sans-serif;
     background-color: #121212; 
   } 
   .pagination button.active {


### PR DESCRIPTION
# 🛠️ Fixes Issue
Fixes: #2563 

# 👨‍💻 Description

## What does this PR do?
The About Us now updates correctly when dark mode is activated. The styling changes appropriately in dark mode to match the rest of the theme.
The "Next" and "Previous" buttons are clearly visible in both modes. 
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
 
# 📄 Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (adds or updates related documentation)

# 📷 Screenshots/GIFs (if any)
![image](https://github.com/user-attachments/assets/38fc4898-a6c9-47ee-add2-5298a02077e4)
![image](https://github.com/user-attachments/assets/dc0914d5-f54e-485a-ba24-9958719c71fe)


# ✅ Checklist
- [x] I am a participant of GSSoC-ext.
- [x] I have followed the contribution guidelines of this project.
- [x] I have made this change from my own. 
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code. 

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.


# 🤝 GSSoC Participation
- [x] This PR is submitted under the GSSoC program.
- [x] I have taken prior approval for this feature/fix.