### PR TITLE
Fix Trends page heading text issue !

### DIFF
--- a/trends.html
+++ b/trends.html
@@ -513,7 +513,7 @@
       top: 0;
       left: 0;
       width: 100%;
-      height: 100%;
+      /*height: 100%;*/
       opacity: 0.8;
     }
 
@@ -521,11 +521,16 @@
       left: 2px;
       text-shadow: -2px 0 red;
       clip: rect(44px, 450px, 56px, 0);
-      animation: glitch-anim 5s infinite linear alternate-reverse;
+      animation: glitch-anim 6s infinite linear alternate-reverse;
     }
 
+    .glitch-effect {
+      position: relative;
+      display: inline-block;
+    }
+    
     .glitch-effect::after {
-      left: -2px;
+      left: 712px;
       text-shadow: -2px 0 blue;
       clip: rect(44px, 450px, 56px, 0);
       animation: glitch-anim2 5s infinite linear alternate-reverse;


### PR DESCRIPTION
Hello, PR
Trends page heading text glitch issue fixed - 


https://github.com/user-attachments/assets/17ccf3ff-ee66-45e9-a341-83646b2e613c

Before -


https://github.com/user-attachments/assets/18d0c1f7-f0cc-4bde-bad9-bea78ed38137



# 📄 Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (adds or updates related documentation)

# ✅ Checklist
- [x] I am a participant of GSSoC-ext.
- [x] I have followed the contribution guidelines of this project.
- [x] I have made this change from my own.
- [x] I have taken help from some online resources.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have added documentation to explain my changes.

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.


# 🤝 GSSoC Participation
- [x] This PR is submitted under the GSSoC program.
- [x] I have taken prior approval for this feature/fix.