### PR TITLE
Fixed homepage visitor counter to track unique visits only once per user session

### DIFF
--- a/newsletterpopup.js
+++ b/newsletterpopup.js
@@ -8,6 +8,10 @@ window.onload = function() {
     document.getElementById('popup-nl').style.display = 'none';
   });
 
+  if (localStorage.getItem("noThanksClicked") === "true") {
+    document.getElementById('popup-nl').style.visibility = 'hidden';
+  }
+
   // // Close the pop-up when clicking outside the pop-up content
   // window.addEventListener('click', function(event) {
   //   const popupContent = document.querySelector('.popup-content'); // Select the popup content
@@ -31,4 +35,5 @@ window.onload = function() {
   document.querySelector('.no-thanks-nl').addEventListener('click', function(event) {
     event.preventDefault();
     document.getElementById('popup-nl').style.display = 'none';
+    localStorage.setItem("noThanksClicked", "true");
   });


### PR DESCRIPTION
#Title : Fixed homepage visitor counter to track unique visits only once per user session

Fix #2657 

## Description
This PR addresses the issue where the visitor count increments each time a user returns to the homepage, even if they have already been counted. The visitor count now only increments on the first visit per user session, ensuring each visitor is counted only once.

@ayush-that Pls assign me this issue, give me labels, level.