### PR TITLE
Overlap fix of placeholder and button

### DIFF
--- a/termsOfUse.html
+++ b/termsOfUse.html
@@ -555,10 +555,10 @@
                     </div>
                     <div class="col-lg-6">
                         <div class="subscribe-form mt-50">
-                            <form id="unique-subscribe-form">
-                                <input type="email" id="unique-news-email" placeholder="Enter Email" required />
+                            <form id="unique-subscribe-form" style=" display: flex; gap: 10px;">
+                                <input style="width: 70%; right: 70px;" type="email" id="unique-news-email" placeholder="Enter Email" required />
                                 <button class="unique-main-btn" id="unique-subscribe-btn"
-                                    type="submit">Subscribe</button>
+                                    type="submit" style="width: 45%;">  Subscribe</button>
                             </form>
                             <div id="unique-message" class="unique-popup-message" style="display: none;">
                                 <div class="border-animation"></div>


### PR DESCRIPTION
# 🛠️ Fixes Issue
Fixes: #2883 
# 👨‍💻 Description

## What does this PR do?

In this PR, I have resolved the issue of the overlapping subscribe placeholder and button to ensure the 'Subscribe to Newsletter' section looks good.
 
# 📄 Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (adds or updates related documentation)

# 📷 Screenshots/GIFs (if any)
 
## Before:
![WhatsApp Image 2024-11-06 at 20 40 05_63ba8380](https://github.com/user-attachments/assets/b576953f-2e82-449f-907e-5cfc64eb2621)



## After:
![WhatsApp Image 2024-11-07 at 11 29 00_7f59470d](https://github.com/user-attachments/assets/13f86425-3e1b-4eb8-a770-b52b88cbe3f6)


# ✅ Checklist
- [x] I am a participant of GSSoC-ext.
- [x] I have followed the contribution guidelines of this project.
- [x] I have made this change from my own.
- [x] I have taken help from some online resources.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have added documentation to explain my changes.

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.


# 🤝 GSSoC Participation
- [x] This PR is submitted under the GSSoC program.
- [x] I have taken prior approval for this feature/fix.