### PR TITLE
FAVICON added to Financial Goal Tracker Challenge Page

### DIFF
--- a/Games/Financial Goal Tracker Challenge.html
+++ b/Games/Financial Goal Tracker Challenge.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Financial Goal Tracker</title>
     <link rel="stylesheet" href="style.css">
+    <link rel="icon" href="https://raw.githubusercontent.com/ayush-that/FinVeda/refs/heads/main/assets/images/Favicon1.ico" type="image/x-icon">
 </head>
 <body>
     <div class="container">


### PR DESCRIPTION
I've added the favicon to "Financial Goal Tracker Challenge Page".
fixes: #2996 

## Before: 
![{10176EE9-D144-4128-B3B7-10DE9D23EB31}](https://github.com/user-attachments/assets/c7dbb536-95a9-402a-8731-614dd46ab3cf)


## After: 
![{30E4FB3E-E0C6-4B73-B33B-331086E8DEBA}](https://github.com/user-attachments/assets/13709d63-f52c-4ec9-b372-ba961292cde5)

