### PR TITLE
FAVICON added to CONTRIBUTORS page

### DIFF
--- a/contributors.html
+++ b/contributors.html
@@ -6,6 +6,7 @@
   <title>Contributors</title>
   <link rel="stylesheet" href="./assets/css/contributors.css">
   <link rel="icon" href="../image/ml-fusion-lab-logo.png">
+  <link rel="icon" href="https://raw.githubusercontent.com/ayush-that/FinVeda/refs/heads/main/assets/images/Favicon1.ico" type="image/x-icon">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.6.0/css/all.min.css" integrity="sha512-Kc323vGBEqzTmouAECnVceyQqyqdsSiqLQISBL29aUW4U/M7pSPA/gEUZQqv1cwx4OnYxTxve5UMg5GT6L4JJg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
 </head>
 <body>


### PR DESCRIPTION
fixes: #3034 
I've added the favicon to "CONTRIBUTORS" page

### Before: 
![image](https://github.com/user-attachments/assets/88007671-f338-4e44-a23a-647c6de7af88)


### After: 
![image](https://github.com/user-attachments/assets/b2ee8024-4ddd-4e66-b3e7-80b49d454a9a)
