### PR TITLE
Added favicon to  "sitemap" page

### DIFF
--- a/blogs/sitemap.html
+++ b/blogs/sitemap.html
@@ -17,7 +17,8 @@
   <link rel="stylesheet" href="../assets/css/style.css" />
   <link rel="stylesheet" href="../assets/css/popup.css" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" />
- <link rel="stylesheet" href="new.css">
+  <link rel="stylesheet" href="new.css">
+  <link rel="icon" href="https://raw.githubusercontent.com/ayush-that/FinVeda/refs/heads/main/assets/images/Favicon1.ico" type="image/x-icon">
   <style>
     #progressBar {
       position: fixed;


### PR DESCRIPTION
fixes: #3036 

I've added the favicon to "sitemap" page. A favicon helps users quickly recognize the app among multiple open tabs, providing a smoother user experience.

![image](https://github.com/user-attachments/assets/3dd057f4-aa60-4052-a9f4-046870c52647)
