### PR TITLE
BUG: "Games" link redirects to 404 error on /tools/sip.html

### DIFF
--- a/tools/sip.html
+++ b/tools/sip.html
@@ -357,7 +357,7 @@
                       </li>
                       <li><a href="../quiz.html"><i class="fas fa-question icon-hover" style="margin: 5px;"></i>
                           Quiz</a></li>
-                          <li><a href="./Games/Games.html"><i class="fas fa-gamepad icon-hover" style="margin: 5px;"></i>
+                          <li><a href="/Games/Games.html"><i class="fas fa-gamepad icon-hover" style="margin: 5px;"></i>
                             Games</a>
                         </li>
                       <li><a href="../maps.html"><i class="fas fa-map icon-hover" style="margin: 5px;"></i> MAPS</a>


### PR DESCRIPTION



# 🛠️ Fixes Issue
Fixes: #3275 

# 👨‍💻 Description

## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Corrected the "Games" page link on `/tools/sip.html` by fixing the relative path issue.
- Changed `href="./Games/Games.html"` to `href="/Games/Games.html"` to resolve the 404 error.
- Ensures users are redirected to the correct page.

# 📄 Type of Change
- [✅] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [  ] Documentation update (adds or updates related documentation)

# 📷 Screenshots/GIFs (if any)
Include screenshots or GIFs to demonstrate your changes

# ✅ Checklist
- [ ] I am a participant of GSSoC-ext.
- [✅] I have followed the contribution guidelines of this project.
- [✅] I have made this change from my own.
- [ ] I have taken help from some online resources.
- [✅] My code follows the style guidelines of this project.
- [✅] I have performed a self-review of my own code.
- [] I have added documentation to explain my changes.

## Mandatory Tasks

- [✅] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

# 🤝 GSSoC Participation
- [ ] This PR is submitted under the GSSoC program.
- [ ] I have taken prior approval for this feature/fix.
