### PR TITLE
Fix: Correct relative path for Courses link in sip.html

### DIFF
--- a/tools/sip.html
+++ b/tools/sip.html
@@ -344,7 +344,7 @@
                     <ul class="dropdown-menu">
 
                       <li>
-                        <a href="./finance.html">
+                        <a href="../finance.html">
                           <i class="fas fa-graduation-cap icon-hover" style="margin: 5px;"></i> Courses
                         </a>
                       </li>


### PR DESCRIPTION
# 🛠️ Fixes Issue
Fixes: #3289

# 👨‍💻 Description

## What does this PR do?

- This PR fixes the issue with the **Courses** link on the `sip.html` page, which was not working as expected due to an incorrect relative path.
- The issue was that the link used `./finance.html` but should have used `../finance.html` to correctly reference the `finance.html` page.
- By fixing the relative path to `../finance.html`, the **Courses** link now works as expected and navigates to the correct page.
- This update enhances the navigation across the site by ensuring all relative paths are accurate, improving the overall user experience.

# 📄 Type of Change
- [✅ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (adds or updates related documentation)

# 📷 Screenshots/GIFs (if any)
Include screenshots or GIFs to demonstrate your changes (if applicable).

# ✅ Checklist
- [ ] I am a participant of GSSoC-ext.
- [✅ ] I have followed the contribution guidelines of this project.
- [✅ ] I have made this change from my own.
- [ ] I have taken help from some online resources.
- [✅ ] My code follows the style guidelines of this project.
- [✅ ] I have performed a self-review of my own code.
- [ ] I have added documentation to explain my changes.

## Mandatory Tasks

- [✅ ] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

# 🤝 GSSoC Participation
- [ ] This PR is submitted under the GSSoC program.
- [ ] I have taken prior approval for this feature/fix.
