### PR TITLE
Fix FD Calculator Buttons and Improve Accessibility with Legend

### DIFF
--- a/tools/FDCalculator.js
+++ b/tools/FDCalculator.js
@@ -1,5 +1,5 @@
 document.addEventListener('DOMContentLoaded', function() {
-    document.getElementById('calculateBtn2').addEventListener('click', function() {
+    document.getElementById('calculatefd').addEventListener('click', function() {
         const principal = parseFloat(document.getElementById('principal').value);
         const rate = parseFloat(document.getElementById('rate').value);
         const years = parseInt(document.getElementById('years1').value);
@@ -25,7 +25,7 @@ document.addEventListener('DOMContentLoaded', function() {
         document.getElementById('maturityAmount').textContent = formatter.format(maturityAmount);
     });
 
-    document.getElementById('clearBtn1').addEventListener('click', function() {
+    document.getElementById('clearfd').addEventListener('click', function() {
         clearInputs();
     });
 

--- a/tools/sip.html
+++ b/tools/sip.html
@@ -2334,23 +2334,25 @@
           <form id="fixed-deposit-calculator"
             style="display: flex; flex-direction: column; justify-content: center; align-items: center;">
             <fieldset>
+              <legend>Fixed Deposit Calculator</legend>
               <div class="form-group">
                 <label for="principal">Principal Amount (₹):</label>
                 <input type="number" id="principal" placeholder="Enter Principal Amount" required>
+                <div id="principalError" class="error-message"></div>
               </div>
               <div class="form-group">
                 <label for="rate">Annual Interest Rate (%):</label>
                 <input type="number" id="rate" step="0.01" placeholder="Enter Annual Interest Rate" required>
+                <div id="rateError" class="error-message"></div>
               </div>
               <div class="form-group">
                 <label for="years">Time Period (in years):</label>
                 <input type="number" id="years1" placeholder="Enter Time Period" required>
+                <div id="yearsError" class="error-message"></div>
               </div>
               <div class="btn-calculate">
-                <button id="calculateBtn2" type="button" class="btn btn-calculate">Calculate</button>
-                <button id="clearBtn1" type="button" class="btn btn-clear">
-                  <p class="btn-text">Clear</p>
-                </button>
+                <button id="calculatefd" type="button" class="btn btn-calculate">Calculate</button>
+                <button id="clearfd" type="button" class="btn btn-clear"> Clear </button>
               </div>
             </fieldset>
           </form>


### PR DESCRIPTION
# 🛠️ Fixes Issue
Fixes: #3336

# 👨‍💻 Description

## What does this PR do?

This pull request addresses the issue with the **FD Calculator** where the **Calculate** and **Clear** buttons are non-functional. After entering valid input for Principal, Rate of Interest, and Time Period, the buttons fail to trigger their intended actions:
- The **Calculate** button does not perform the calculation or display any results.
- The **Clear** button does not reset the input fields or remove the results.

This fix ensures that both buttons function as expected, providing the user with the ability to:
- Calculate the total interest and maturity amount based on the entered values.
- Clear the input fields and any displayed results.

Additionally, a legend has been added to the FD Calculator for better accessibility and context, helping users understand the purpose of each input section.

# 📄 Type of Change
- [✅ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (adds or updates related documentation)

# 📷 Screenshots/GIFs (if any)

**Before the Fix:**

The screenshot shows the FD Calculator interface with the Calculate and Clear buttons present. Despite entering valid values for Principal, Rate of Interest, and Time Period, clicking the Calculate button does not trigger any calculation or display results. Similarly, clicking the Clear button does not reset the input fields or clear the displayed results. The buttons are visually present but do not function as expected, resulting in a non-interactive user experience.

<img width="1440" alt="Screenshot 2024-11-25 at 8 47 31 AM" src="https://github.com/user-attachments/assets/02f97fc8-2157-436a-924c-c37af755acf7">


**After the Fix:**

The screenshot shows the FD Calculator interface after the fix has been implemented. Now, clicking the Calculate button correctly triggers the calculation of total interest and maturity amount, displaying the results as expected. The Clear button also functions as intended, resetting the input fields and clearing any displayed results, providing a fully interactive and responsive user experience.

<img width="1433" alt="Screenshot 2024-11-25 at 10 09 34 AM" src="https://github.com/user-attachments/assets/4bae082a-7121-4d6a-a3b3-c03cfae93100">


# ✅ Checklist
- [ ] I am a participant of GSSoC-ext.
- [✅ ] I have followed the contribution guidelines of this project.
- [✅ ] I have made this change from my own.
- [] I have taken help from some online resources.
- [✅ ] My code follows the style guidelines of this project.
- [✅ ] I have performed a self-review of my own code.
- [] I have added documentation to explain my changes.

## Mandatory Tasks

- [✅ ] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

# 🤝 GSSoC Participation
- [ ] This PR is submitted under the GSSoC program.
- [ ] I have taken prior approval for this feature/fix.
